### PR TITLE
Replace @Sendable closures with new 'sending' syntax

### DIFF
--- a/Source/Core/DataRequest.swift
+++ b/Source/Core/DataRequest.swift
@@ -33,9 +33,9 @@ public class DataRequest: Request, @unchecked Sendable {
 
     private struct DataMutableState {
         var data: Data?
-        var httpResponseHandler: (queue: DispatchQueue,
-                                  handler: @Sendable (_ response: HTTPURLResponse,
-                                                      _ completionHandler: @escaping @Sendable (ResponseDisposition) -> Void) -> Void)?
+        var httpResponseHandler:(queue: DispatchQueue,
+                                  handler:  (_ response: HTTPURLResponse,
+                                                      _ completionHandler: @escaping  (ResponseDisposition) -> sending Void) -> Void)?
     }
 
     private let dataMutableState = Protected(DataMutableState())
@@ -93,7 +93,7 @@ public class DataRequest: Request, @unchecked Sendable {
         updateDownloadProgress()
     }
 
-    func didReceiveResponse(_ response: HTTPURLResponse, completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void) {
+    func didReceiveResponse(_ response: HTTPURLResponse, completionHandler: @escaping  (URLSession.ResponseDisposition) -> sending Void) {
         dataMutableState.read { dataMutableState in
             guard let httpResponseHandler = dataMutableState.httpResponseHandler else {
                 underlyingQueue.async { completionHandler(.allow) }
@@ -117,7 +117,7 @@ public class DataRequest: Request, @unchecked Sendable {
         }
     }
 
-    override func task(for request: URLRequest, using session: URLSession) -> URLSessionTask {
+    override func task(for request: URLRequest, using session: URLSession) -> sending URLSessionTask {
         let copiedRequest = request
         return session.dataTask(with: copiedRequest)
     }
@@ -142,8 +142,8 @@ public class DataRequest: Request, @unchecked Sendable {
     /// - Returns:              The instance.
     @preconcurrency
     @discardableResult
-    public func validate(_ validation: @escaping Validation) -> Self {
-        let validator: @Sendable () -> Void = { [unowned self] in
+    public func validate(_ validation: @escaping Validation) -> sending Self {
+        let validator: () -> sending Void = { [unowned self] in
             guard error == nil, let response else { return }
 
             let result = validation(request, response, data)
@@ -176,8 +176,8 @@ public class DataRequest: Request, @unchecked Sendable {
     @discardableResult
     public func onHTTPResponse(
         on queue: DispatchQueue = .main,
-        perform handler: @escaping @Sendable (_ response: HTTPURLResponse,
-                                              _ completionHandler: @escaping @Sendable (ResponseDisposition) -> Void) -> Void
+        perform handler: @escaping  (_ response: HTTPURLResponse,
+                                              _ completionHandler: @escaping  (ResponseDisposition) -> sending Void) -> Void
     ) -> Self {
         dataMutableState.write { mutableState in
             mutableState.httpResponseHandler = (queue, handler)
@@ -196,7 +196,7 @@ public class DataRequest: Request, @unchecked Sendable {
     @preconcurrency
     @discardableResult
     public func onHTTPResponse(on queue: DispatchQueue = .main,
-                               perform handler: @escaping @Sendable (HTTPURLResponse) -> Void) -> Self {
+                               perform handler: @escaping  (HTTPURLResponse) -> sending Void) -> Self {
         onHTTPResponse(on: queue) { response, completionHandler in
             handler(response)
             completionHandler(.allow)
@@ -216,7 +216,7 @@ public class DataRequest: Request, @unchecked Sendable {
     /// - Returns:             The request.
     @preconcurrency
     @discardableResult
-    public func response(queue: DispatchQueue = .main, completionHandler: @escaping @Sendable (AFDataResponse<Data?>) -> Void) -> Self {
+    public func response(queue: DispatchQueue = .main, completionHandler: @escaping  (AFDataResponse<Data?>) -> sending Void) -> Self {
         appendResponseSerializer {
             // Start work that should be on the serialization queue.
             let result = AFResult<Data?>(value: self.data, error: self.error)
@@ -241,7 +241,7 @@ public class DataRequest: Request, @unchecked Sendable {
 
     private func _response<Serializer: DataResponseSerializerProtocol>(queue: DispatchQueue = .main,
                                                                        responseSerializer: Serializer,
-                                                                       completionHandler: @escaping @Sendable (AFDataResponse<Serializer.SerializedObject>) -> Void)
+                                                                       completionHandler: @escaping  (AFDataResponse<Serializer.SerializedObject>) -> sending Void)
         -> Self {
         appendResponseSerializer {
             // Start work that should be on the serialization queue.
@@ -274,7 +274,7 @@ public class DataRequest: Request, @unchecked Sendable {
                 }
 
                 delegate.retryResult(for: self, dueTo: serializerError) { retryResult in
-                    var didComplete: (@Sendable () -> Void)?
+                    var didComplete:( () -> sending Void)?
 
                     defer {
                         if let didComplete {
@@ -320,7 +320,7 @@ public class DataRequest: Request, @unchecked Sendable {
     @discardableResult
     public func response<Serializer: DataResponseSerializerProtocol>(queue: DispatchQueue = .main,
                                                                      responseSerializer: Serializer,
-                                                                     completionHandler: @escaping @Sendable (AFDataResponse<Serializer.SerializedObject>) -> Void)
+                                                                     completionHandler: @escaping  (AFDataResponse<Serializer.SerializedObject>) -> sending Void)
         -> Self {
         _response(queue: queue, responseSerializer: responseSerializer, completionHandler: completionHandler)
     }
@@ -337,7 +337,7 @@ public class DataRequest: Request, @unchecked Sendable {
     @discardableResult
     public func response<Serializer: ResponseSerializer>(queue: DispatchQueue = .main,
                                                          responseSerializer: Serializer,
-                                                         completionHandler: @escaping @Sendable (AFDataResponse<Serializer.SerializedObject>) -> Void)
+                                                         completionHandler: @escaping  (AFDataResponse<Serializer.SerializedObject>) -> sending Void)
         -> Self {
         _response(queue: queue, responseSerializer: responseSerializer, completionHandler: completionHandler)
     }
@@ -359,7 +359,7 @@ public class DataRequest: Request, @unchecked Sendable {
                              dataPreprocessor: any DataPreprocessor = DataResponseSerializer.defaultDataPreprocessor,
                              emptyResponseCodes: Set<Int> = DataResponseSerializer.defaultEmptyResponseCodes,
                              emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods,
-                             completionHandler: @escaping @Sendable (AFDataResponse<Data>) -> Void) -> Self {
+                             completionHandler: @escaping  (AFDataResponse<Data>) -> sending Void) -> Self {
         response(queue: queue,
                  responseSerializer: DataResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                             emptyResponseCodes: emptyResponseCodes,
@@ -387,7 +387,7 @@ public class DataRequest: Request, @unchecked Sendable {
                                encoding: String.Encoding? = nil,
                                emptyResponseCodes: Set<Int> = StringResponseSerializer.defaultEmptyResponseCodes,
                                emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods,
-                               completionHandler: @escaping @Sendable (AFDataResponse<String>) -> Void) -> Self {
+                               completionHandler: @escaping  (AFDataResponse<String>) -> sending Void) -> Self {
         response(queue: queue,
                  responseSerializer: StringResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                               encoding: encoding,
@@ -417,7 +417,7 @@ public class DataRequest: Request, @unchecked Sendable {
                              emptyResponseCodes: Set<Int> = JSONResponseSerializer.defaultEmptyResponseCodes,
                              emptyRequestMethods: Set<HTTPMethod> = JSONResponseSerializer.defaultEmptyRequestMethods,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
-                             completionHandler: @escaping @Sendable (AFDataResponse<Any>) -> Void) -> Self {
+                             completionHandler: @escaping  (AFDataResponse<Any>) -> sending Void) -> Self {
         response(queue: queue,
                  responseSerializer: JSONResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                             emptyResponseCodes: emptyResponseCodes,
@@ -447,7 +447,7 @@ public class DataRequest: Request, @unchecked Sendable {
                                          decoder: any DataDecoder = JSONDecoder(),
                                          emptyResponseCodes: Set<Int> = DecodableResponseSerializer<Value>.defaultEmptyResponseCodes,
                                          emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<Value>.defaultEmptyRequestMethods,
-                                         completionHandler: @escaping @Sendable (AFDataResponse<Value>) -> Void) -> Self where Value: Decodable, Value: Sendable {
+                                         completionHandler: @escaping (AFDataResponse<Value>) -> sending Void) -> Self where Value: Decodable, Value: Sendable {
         response(queue: queue,
                  responseSerializer: DecodableResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                                  decoder: decoder,

--- a/Source/Core/DataStreamRequest.swift
+++ b/Source/Core/DataStreamRequest.swift
@@ -27,7 +27,7 @@ import Foundation
 /// `Request` subclass which streams HTTP response `Data` through a `Handler` closure.
 public final class DataStreamRequest: Request, @unchecked Sendable {
     /// Closure type handling `DataStreamRequest.Stream` values.
-    public typealias Handler<Success, Failure: Error> = @Sendable (Stream<Success, Failure>) throws -> Void
+    public typealias Handler<Success, Failure: Error> = (Stream<Success, Failure>) throws -> sending Void
 
     /// Type encapsulating an `Event` as it flows through the stream, as well as a `CancellationToken` which can be used
     /// to stop the stream at any time.
@@ -90,16 +90,16 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
         /// `OutputStream` bound to the `InputStream` produced by `asInputStream`, if it has been called.
         var outputStream: OutputStream?
         /// Stream closures called as `Data` is received.
-        var streams: [@Sendable (_ data: Data) -> Void] = []
+        var streams: [(_ data: Data) -> sending Void] = []
         /// Number of currently executing streams. Used to ensure completions are only fired after all streams are
         /// enqueued.
         var numberOfExecutingStreams = 0
         /// Completion calls enqueued while streams are still executing.
-        var enqueuedCompletionEvents: [@Sendable () -> Void] = []
+        var enqueuedCompletionEvents: [() -> sending Void] = []
         /// Handler for any `HTTPURLResponse`s received.
-        var httpResponseHandler: (queue: DispatchQueue,
-                                  handler: @Sendable (_ response: HTTPURLResponse,
-                                                      _ completionHandler: @escaping @Sendable (ResponseDisposition) -> Void) -> Void)?
+        var httpResponseHandler:(queue: DispatchQueue,
+                                  handler:  (_ response: HTTPURLResponse,
+                                                      _ completionHandler: @escaping  (ResponseDisposition) -> sending Void) -> Void)?
     }
 
     let streamMutableState = Protected(StreamMutableState())
@@ -140,7 +140,7 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
                    delegate: delegate)
     }
 
-    override func task(for request: URLRequest, using session: URLSession) -> URLSessionTask {
+    override func task(for request: URLRequest, using session: URLSession) -> sending URLSessionTask {
         let copiedRequest = request
         return session.dataTask(with: copiedRequest)
     }
@@ -168,7 +168,7 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
         }
     }
 
-    func didReceiveResponse(_ response: HTTPURLResponse, completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void) {
+    func didReceiveResponse(_ response: HTTPURLResponse, completionHandler: @escaping  (URLSession.ResponseDisposition) -> sending Void) {
         streamMutableState.read { dataMutableState in
             guard let httpResponseHandler = dataMutableState.httpResponseHandler else {
                 underlyingQueue.async { completionHandler(.allow) }
@@ -198,8 +198,8 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     ///
     /// - Returns:              The `DataStreamRequest`.
     @discardableResult
-    public func validate(_ validation: @escaping Validation) -> Self {
-        let validator: @Sendable () -> Void = { [unowned self] in
+    public func validate(_ validation: @escaping Validation) -> sending Self {
+        let validator: () -> sending Void = { [unowned self] in
             guard error == nil, let response else { return }
 
             let result = validation(request, response)
@@ -229,7 +229,7 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     /// - Parameter bufferSize: Size, in bytes, of the buffer between the `OutputStream` and `InputStream`.
     ///
     /// - Returns:              The `InputStream` bound to the internal `OutboundStream`.
-    public func asInputStream(bufferSize: Int = 1024) -> InputStream? {
+    public func asInputStream(bufferSize: Int = 1024) -> sending InputStream? {
         defer { resume() }
 
         var inputStream: InputStream?
@@ -258,8 +258,8 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     @discardableResult
     public func onHTTPResponse(
         on queue: DispatchQueue = .main,
-        perform handler: @escaping @Sendable (_ response: HTTPURLResponse,
-                                              _ completionHandler: @escaping @Sendable (ResponseDisposition) -> Void) -> Void
+        perform handler: @escaping  (_ response: HTTPURLResponse,
+                                              _ completionHandler: @escaping  (ResponseDisposition) -> sending Void) -> Void
     ) -> Self {
         streamMutableState.write { mutableState in
             mutableState.httpResponseHandler = (queue, handler)
@@ -278,7 +278,7 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     @preconcurrency
     @discardableResult
     public func onHTTPResponse(on queue: DispatchQueue = .main,
-                               perform handler: @escaping @Sendable (HTTPURLResponse) -> Void) -> Self {
+                               perform handler: @escaping  (HTTPURLResponse) -> sending Void) -> Self {
         onHTTPResponse(on: queue) { response, completionHandler in
             handler(response)
             completionHandler(.allow)
@@ -287,7 +287,7 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
         return self
     }
 
-    func capturingError(from closure: () throws -> Void) {
+    func capturingError(from closure: () throws -> sending Void) {
         do {
             try closure()
         } catch {
@@ -343,8 +343,8 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     /// - Returns:  The `DataStreamRequest`.
     @preconcurrency
     @discardableResult
-    public func responseStream(on queue: DispatchQueue = .main, stream: @escaping Handler<Data, Never>) -> Self {
-        let parser = { @Sendable [unowned self] (data: Data) in
+    public func responseStream(on queue: DispatchQueue = .main, stream: @escaping Handler<Data, Never>) -> sending Self {
+        let parser = {  [unowned self] (data: Data) in
             queue.async {
                 self.capturingError {
                     try stream(.init(event: .stream(.success(data)), token: .init(self)))
@@ -372,8 +372,8 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     @discardableResult
     public func responseStream<Serializer: DataStreamSerializer>(using serializer: Serializer,
                                                                  on queue: DispatchQueue = .main,
-                                                                 stream: @escaping Handler<Serializer.SerializedObject, AFError>) -> Self {
-        let parser = { @Sendable [unowned self] (data: Data) in
+                                                                 stream: @escaping Handler<Serializer.SerializedObject, AFError>) -> sending Self {
+        let parser = {  [unowned self] (data: Data) in
             serializationQueue.async {
                 // Start work on serialization queue.
                 let result = Result { try serializer.serialize(data) }
@@ -413,8 +413,8 @@ public final class DataStreamRequest: Request, @unchecked Sendable {
     @preconcurrency
     @discardableResult
     public func responseStreamString(on queue: DispatchQueue = .main,
-                                     stream: @escaping Handler<String, Never>) -> Self {
-        let parser = { @Sendable [unowned self] (data: Data) in
+                                     stream: @escaping Handler<String, Never>) -> sending Self {
+        let parser = {  [unowned self] (data: Data) in
             serializationQueue.async {
                 // Start work on serialization queue.
                 let string = String(decoding: data, as: UTF8.self)
@@ -516,7 +516,7 @@ public protocol DataStreamSerializer: Sendable {
     /// - Parameter data: `Data` to be serialized.
     ///
     /// - Throws: Any error produced during serialization.
-    func serialize(_ data: Data) throws -> SerializedObject
+    func serialize(_ data: Data) throws -> sending SerializedObject
 }
 
 /// `DataStreamSerializer` which uses the provided `DataPreprocessor` and `DataDecoder` to serialize the incoming `Data`.
@@ -536,7 +536,7 @@ public struct DecodableStreamSerializer<T: Decodable>: DataStreamSerializer wher
         self.dataPreprocessor = dataPreprocessor
     }
 
-    public func serialize(_ data: Data) throws -> T {
+    public func serialize(_ data: Data) throws -> sending T {
         let processedData = try dataPreprocessor.preprocess(data)
         do {
             return try decoder.decode(T.self, from: processedData)
@@ -551,7 +551,7 @@ public struct PassthroughStreamSerializer: DataStreamSerializer {
     /// Creates an instance.
     public init() {}
 
-    public func serialize(_ data: Data) throws -> Data { data }
+    public func serialize(_ data: Data) throws -> sending Data { data }
 }
 
 /// `DataStreamSerializer` which serializes incoming stream `Data` into `UTF8`-decoded `String` values.
@@ -559,7 +559,7 @@ public struct StringStreamSerializer: DataStreamSerializer {
     /// Creates an instance.
     public init() {}
 
-    public func serialize(_ data: Data) throws -> String {
+    public func serialize(_ data: Data) throws -> sending String {
         String(decoding: data, as: UTF8.self)
     }
 }

--- a/Source/Core/DownloadRequest.swift
+++ b/Source/Core/DownloadRequest.swift
@@ -50,8 +50,8 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     ///
     /// - Note: Downloads from a local `file://` `URL`s do not use the `Destination` closure, as those downloads do not
     ///         return an `HTTPURLResponse`. Instead the file is merely moved within the temporary directory.
-    public typealias Destination = @Sendable (_ temporaryURL: URL,
-                                              _ response: HTTPURLResponse) -> (destinationURL: URL, options: Options)
+    public typealias Destination = (_ temporaryURL: URL,
+                                              _ response: HTTPURLResponse) -> sending (destinationURL: URL, options: Options)
 
     /// Creates a download file destination closure which uses the default file manager to move the temporary file to a
     /// file URL in the first available directory with the specified search path directory and search path domain mask.
@@ -64,7 +64,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     /// - Returns: The `Destination` closure.
     public class func suggestedDownloadDestination(for directory: FileManager.SearchPathDirectory = .documentDirectory,
                                                    in domain: FileManager.SearchPathDomainMask = .userDomainMask,
-                                                   options: Options = []) -> Destination {
+                                                   options: Options = []) -> sending Destination {
         { temporaryURL, response in
             let directoryURLs = FileManager.default.urls(for: directory, in: domain)
             let url = directoryURLs.first?.appendingPathComponent(response.suggestedFilename!) ?? temporaryURL
@@ -83,7 +83,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
 
     /// Default `URL` creation closure. Creates a `URL` in the temporary directory with `Alamofire_` prepended to the
     /// provided file name.
-    static let defaultDestinationURL: @Sendable (URL) -> URL = { url in
+    static let defaultDestinationURL: (URL) -> sending URL = { url in
         let filename = "Alamofire_\(url.lastPathComponent)"
         let destination = url.deletingLastPathComponent().appendingPathComponent(filename)
 
@@ -201,7 +201,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
         downloadProgressHandler?.queue.async { self.downloadProgressHandler?.handler(self.downloadProgress) }
     }
 
-    override func task(for request: URLRequest, using session: URLSession) -> URLSessionTask {
+    override func task(for request: URLRequest, using session: URLSession) -> sending URLSessionTask {
         session.downloadTask(with: request)
     }
 
@@ -212,7 +212,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     ///   - session: `URLSession` used to create the `URLSessionTask`.
     ///
     /// - Returns:   The `URLSessionTask` created.
-    public func task(forResumeData data: Data, using session: URLSession) -> URLSessionTask {
+    public func task(forResumeData data: Data, using session: URLSession) -> sending URLSessionTask {
         session.downloadTask(withResumeData: data)
     }
 
@@ -223,7 +223,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     ///
     /// - Returns: The instance.
     @discardableResult
-    override public func cancel() -> Self {
+    override public func cancel() -> sending Self {
         cancel(producingResumeData: false)
     }
 
@@ -235,8 +235,8 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     ///
     /// - Returns: The instance.
     @discardableResult
-    public func cancel(producingResumeData shouldProduceResumeData: Bool) -> Self {
-        cancel(optionallyProducingResumeData: shouldProduceResumeData ? { @Sendable _ in } : nil)
+    public func cancel(producingResumeData shouldProduceResumeData: Bool) -> sending Self {
+        cancel(optionallyProducingResumeData: shouldProduceResumeData ? ({ _ in } as (_: Data?) -> sending Void) : nil)
     }
 
     /// Cancels the instance while producing resume data. Once cancelled, a `DownloadRequest` can no longer be resumed
@@ -252,7 +252,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     /// - Returns:                     The instance.
     @preconcurrency
     @discardableResult
-    public func cancel(byProducingResumeData completionHandler: @escaping @Sendable (_ data: Data?) -> Void) -> Self {
+    public func cancel(byProducingResumeData completionHandler: @escaping  (_ data: Data?) -> sending Void) -> Self {
         cancel(optionallyProducingResumeData: completionHandler)
     }
 
@@ -262,7 +262,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     /// - Parameter completionHandler: Optional resume data handler.
     ///
     /// - Returns:                     The instance.
-    private func cancel(optionallyProducingResumeData completionHandler: (@Sendable (_ resumeData: Data?) -> Void)?) -> Self {
+    private func cancel(optionallyProducingResumeData completionHandler: ( (_ resumeData: Data?) -> sending Void)?) -> Self {
         mutableState.write { mutableState in
             guard mutableState.state.canTransitionTo(.cancelled) else { return }
 
@@ -302,8 +302,8 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     ///
     /// - Returns:              The instance.
     @discardableResult
-    public func validate(_ validation: @escaping Validation) -> Self {
-        let validator: @Sendable () -> Void = { [unowned self] in
+    public func validate(_ validation: @escaping Validation) -> sending Self {
+        let validator: () -> sending Void = { [unowned self] in
             guard error == nil, let response else { return }
 
             let result = validation(request, response, fileURL)
@@ -336,7 +336,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     @preconcurrency
     @discardableResult
     public func response(queue: DispatchQueue = .main,
-                         completionHandler: @escaping @Sendable (AFDownloadResponse<URL?>) -> Void)
+                         completionHandler: @escaping  (AFDownloadResponse<URL?>) -> sending Void)
         -> Self {
         appendResponseSerializer {
             // Start work that should be on the serialization queue.
@@ -363,7 +363,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
 
     private func _response<Serializer: DownloadResponseSerializerProtocol>(queue: DispatchQueue = .main,
                                                                            responseSerializer: Serializer,
-                                                                           completionHandler: @escaping @Sendable (AFDownloadResponse<Serializer.SerializedObject>) -> Void)
+                                                                           completionHandler: @escaping  (AFDownloadResponse<Serializer.SerializedObject>) -> sending Void)
         -> Self {
         appendResponseSerializer {
             // Start work that should be on the serialization queue.
@@ -396,7 +396,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
                 }
 
                 delegate.retryResult(for: self, dueTo: serializerError) { retryResult in
-                    var didComplete: (@Sendable () -> Void)?
+                    var didComplete:( () -> sending Void)?
 
                     defer {
                         if let didComplete {
@@ -445,7 +445,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     @discardableResult
     public func response<Serializer: DownloadResponseSerializerProtocol>(queue: DispatchQueue = .main,
                                                                          responseSerializer: Serializer,
-                                                                         completionHandler: @escaping @Sendable (AFDownloadResponse<Serializer.SerializedObject>) -> Void)
+                                                                         completionHandler: @escaping  (AFDownloadResponse<Serializer.SerializedObject>) -> sending Void)
         -> Self {
         _response(queue: queue, responseSerializer: responseSerializer, completionHandler: completionHandler)
     }
@@ -464,7 +464,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     @discardableResult
     public func response<Serializer: ResponseSerializer>(queue: DispatchQueue = .main,
                                                          responseSerializer: Serializer,
-                                                         completionHandler: @escaping @Sendable (AFDownloadResponse<Serializer.SerializedObject>) -> Void)
+                                                         completionHandler: @escaping  (AFDownloadResponse<Serializer.SerializedObject>) -> sending Void)
         -> Self {
         _response(queue: queue, responseSerializer: responseSerializer, completionHandler: completionHandler)
     }
@@ -479,7 +479,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
     @preconcurrency
     @discardableResult
     public func responseURL(queue: DispatchQueue = .main,
-                            completionHandler: @escaping @Sendable (AFDownloadResponse<URL>) -> Void) -> Self {
+                            completionHandler: @escaping  (AFDownloadResponse<URL>) -> sending Void) -> Self {
         response(queue: queue, responseSerializer: URLResponseSerializer(), completionHandler: completionHandler)
     }
 
@@ -502,7 +502,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
                              dataPreprocessor: any DataPreprocessor = DataResponseSerializer.defaultDataPreprocessor,
                              emptyResponseCodes: Set<Int> = DataResponseSerializer.defaultEmptyResponseCodes,
                              emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods,
-                             completionHandler: @escaping @Sendable (AFDownloadResponse<Data>) -> Void) -> Self {
+                             completionHandler: @escaping  (AFDownloadResponse<Data>) -> sending Void) -> Self {
         response(queue: queue,
                  responseSerializer: DataResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                             emptyResponseCodes: emptyResponseCodes,
@@ -532,7 +532,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
                                encoding: String.Encoding? = nil,
                                emptyResponseCodes: Set<Int> = StringResponseSerializer.defaultEmptyResponseCodes,
                                emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods,
-                               completionHandler: @escaping @Sendable (AFDownloadResponse<String>) -> Void) -> Self {
+                               completionHandler: @escaping  (AFDownloadResponse<String>) -> sending Void) -> Self {
         response(queue: queue,
                  responseSerializer: StringResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                               encoding: encoding,
@@ -564,7 +564,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
                              emptyResponseCodes: Set<Int> = JSONResponseSerializer.defaultEmptyResponseCodes,
                              emptyRequestMethods: Set<HTTPMethod> = JSONResponseSerializer.defaultEmptyRequestMethods,
                              options: JSONSerialization.ReadingOptions = .allowFragments,
-                             completionHandler: @escaping @Sendable (AFDownloadResponse<Any>) -> Void) -> Self {
+                             completionHandler: @escaping  (AFDownloadResponse<Any>) -> sending Void) -> Self {
         response(queue: queue,
                  responseSerializer: JSONResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                             emptyResponseCodes: emptyResponseCodes,
@@ -596,7 +596,7 @@ public final class DownloadRequest: Request, @unchecked Sendable {
                                                 decoder: any DataDecoder = JSONDecoder(),
                                                 emptyResponseCodes: Set<Int> = DecodableResponseSerializer<T>.defaultEmptyResponseCodes,
                                                 emptyRequestMethods: Set<HTTPMethod> = DecodableResponseSerializer<T>.defaultEmptyRequestMethods,
-                                                completionHandler: @escaping @Sendable (AFDownloadResponse<T>) -> Void) -> Self where T: Sendable {
+                                                completionHandler: @escaping (AFDownloadResponse<T>) -> sending Void) -> Self where T: Sendable {
         response(queue: queue,
                  responseSerializer: DecodableResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                                  decoder: decoder,

--- a/Source/Core/ParameterEncoding.swift
+++ b/Source/Core/ParameterEncoding.swift
@@ -37,7 +37,7 @@ public protocol ParameterEncoding: Sendable {
     ///
     /// - Returns:      The encoded `URLRequest`.
     /// - Throws:       Any `Error` produced during parameter encoding.
-    func encode(_ urlRequest: any URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest
+    func encode(_ urlRequest: any URLRequestConvertible, with parameters: Parameters?) throws -> sending URLRequest
 }
 
 // MARK: -
@@ -70,7 +70,7 @@ public struct URLEncoding: ParameterEncoding {
         /// Sets encoded query string result as the HTTP body of the URL request.
         case httpBody
 
-        func encodesParametersInURL(for method: HTTPMethod) -> Bool {
+        func encodesParametersInURL(for method: HTTPMethod) -> sending Bool {
             switch self {
             case .methodDependent: [.get, .head, .delete].contains(method)
             case .queryString: true
@@ -88,9 +88,9 @@ public struct URLEncoding: ParameterEncoding {
         /// Brackets containing the item index are appended. This matches the jQuery and Node.js behavior.
         case indexInBrackets
         /// Provide a custom array key encoding with the given closure.
-        case custom(@Sendable (_ key: String, _ index: Int) -> String)
+        case custom( (_ key: String, _ index: Int) -> sending String)
 
-        func encode(key: String, atIndex index: Int) -> String {
+        func encode(key: String, atIndex index: Int) -> sending String {
             switch self {
             case .brackets:
                 "\(key)[]"
@@ -111,7 +111,7 @@ public struct URLEncoding: ParameterEncoding {
         /// Encode `true` and `false` as string literals.
         case literal
 
-        func encode(value: Bool) -> String {
+        func encode(value: Bool) -> sending String {
             switch self {
             case .numeric:
                 value ? "1" : "0"
@@ -160,7 +160,7 @@ public struct URLEncoding: ParameterEncoding {
 
     // MARK: Encoding
 
-    public func encode(_ urlRequest: any URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
+    public func encode(_ urlRequest: any URLRequestConvertible, with parameters: Parameters?) throws -> sending URLRequest {
         var urlRequest = try urlRequest.asURLRequest()
 
         guard let parameters else { return urlRequest }
@@ -193,7 +193,7 @@ public struct URLEncoding: ParameterEncoding {
     ///   - value: Value of the query component.
     ///
     /// - Returns: The percent-escaped, URL encoded query string components.
-    public func queryComponents(fromKey key: String, value: Any) -> [(String, String)] {
+    public func queryComponents(fromKey key: String, value: Any) -> sending [(String, String)] {
         var components: [(String, String)] = []
         switch value {
         case let dictionary as [String: Any]:
@@ -223,11 +223,11 @@ public struct URLEncoding: ParameterEncoding {
     /// - Parameter string: `String` to be percent-escaped.
     ///
     /// - Returns:          The percent-escaped `String`.
-    public func escape(_ string: String) -> String {
+    public func escape(_ string: String) -> sending String {
         string.addingPercentEncoding(withAllowedCharacters: .afURLQueryAllowed) ?? string
     }
 
-    private func query(_ parameters: [String: Any]) -> String {
+    private func query(_ parameters: [String: Any]) -> sending String {
         var components: [(String, String)] = []
 
         for key in parameters.keys.sorted(by: <) {
@@ -272,7 +272,7 @@ public struct JSONEncoding: ParameterEncoding {
 
     // MARK: Encoding
 
-    public func encode(_ urlRequest: any URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
+    public func encode(_ urlRequest: any URLRequestConvertible, with parameters: Parameters?) throws -> sending URLRequest {
         var urlRequest = try urlRequest.asURLRequest()
 
         guard let parameters else { return urlRequest }
@@ -304,7 +304,7 @@ public struct JSONEncoding: ParameterEncoding {
     ///
     /// - Returns:      The encoded `URLRequest`.
     /// - Throws:       Any `Error` produced during encoding.
-    public func encode(_ urlRequest: any URLRequestConvertible, withJSONObject jsonObject: Any? = nil) throws -> URLRequest {
+    public func encode(_ urlRequest: any URLRequestConvertible, withJSONObject jsonObject: Any? = nil) throws -> sending URLRequest {
         var urlRequest = try urlRequest.asURLRequest()
 
         guard let jsonObject else { return urlRequest }

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -47,7 +47,7 @@ public class Request: @unchecked Sendable {
         case finished
 
         /// Determines whether `self` can be transitioned to the provided `State`.
-        func canTransitionTo(_ state: State) -> Bool {
+        func canTransitionTo(_ state: State) -> sending Bool {
             switch (self, state) {
             case (.initialized, _):
                 true
@@ -93,15 +93,15 @@ public class Request: @unchecked Sendable {
         /// `CachedResponseHandler` provided to handle response caching.
         var cachedResponseHandler: (any CachedResponseHandler)?
         /// Queue and closure called when the `Request` is able to create a cURL description of itself.
-        var cURLHandler: (queue: DispatchQueue, handler: @Sendable (String) -> Void)?
+        var cURLHandler:(queue: DispatchQueue, handler:  (String) -> sending Void)?
         /// Queue and closure called when the `Request` creates a `URLRequest`.
-        var urlRequestHandler: (queue: DispatchQueue, handler: @Sendable (URLRequest) -> Void)?
+        var urlRequestHandler:(queue: DispatchQueue, handler:  (URLRequest) -> sending Void)?
         /// Queue and closure called when the `Request` creates a `URLSessionTask`.
-        var urlSessionTaskHandler: (queue: DispatchQueue, handler: @Sendable (URLSessionTask) -> Void)?
+        var urlSessionTaskHandler:(queue: DispatchQueue, handler:  (URLSessionTask) -> sending Void)?
         /// Response serialization closures that handle response parsing.
-        var responseSerializers: [@Sendable () -> Void] = []
+        var responseSerializers: [() -> sending Void] = []
         /// Response serialization completion closures executed once all response serializers are complete.
-        var responseSerializerCompletions: [@Sendable () -> Void] = []
+        var responseSerializerCompletions: [() -> sending Void] = []
         /// Whether response serializer processing is finished.
         var responseSerializerProcessingFinished = false
         /// `URLCredential` used for authentication challenges.
@@ -121,7 +121,7 @@ public class Request: @unchecked Sendable {
         /// representation in the state machine in the future.
         var isFinishing = false
         /// Actions to run when requests are finished. Use for concurrency support.
-        var finishHandlers: [() -> Void] = []
+        var finishHandlers: [() -> sending Void] = []
     }
 
     /// Protected `MutableState` value that provides thread-safe access to state values.
@@ -143,7 +143,7 @@ public class Request: @unchecked Sendable {
     // MARK: Progress
 
     /// Closure type executed when monitoring the upload or download progress of a request.
-    public typealias ProgressHandler = @Sendable (_ progress: Progress) -> Void
+    public typealias ProgressHandler = (_ progress: Progress) -> sending Void
 
     /// `Progress` of the upload of the body of the executed `URLRequest`. Reset to `0` if the `Request` is retried.
     public let uploadProgress = Progress(totalUnitCount: 0)
@@ -188,7 +188,7 @@ public class Request: @unchecked Sendable {
     // MARK: Validators
 
     /// `Validator` callback closures that store the validation calls enqueued.
-    let validators = Protected<[@Sendable () -> Void]>([])
+    let validators = Protected<[() -> sending Void]>([])
 
     // MARK: URLRequests
 
@@ -533,7 +533,7 @@ public class Request: @unchecked Sendable {
     ///  - Note: This method will also `resume` the instance if `delegate.startImmediately` returns `true`.
     ///
     /// - Parameter closure: The closure containing the response serialization call.
-    func appendResponseSerializer(_ closure: @escaping @Sendable () -> Void) {
+    func appendResponseSerializer(_ closure: @escaping  () -> sending Void) {
         mutableState.write { mutableState in
             mutableState.responseSerializers.append(closure)
 
@@ -554,8 +554,8 @@ public class Request: @unchecked Sendable {
     /// Returns the next response serializer closure to execute if there's one left.
     ///
     /// - Returns: The next response serialization closure, if there is one.
-    func nextResponseSerializer() -> (@Sendable () -> Void)? {
-        var responseSerializer: (@Sendable () -> Void)?
+    func nextResponseSerializer() -> sending ( () -> sending Void)? {
+        var responseSerializer:( () -> sending Void)?
 
         mutableState.write { mutableState in
             let responseSerializerIndex = mutableState.responseSerializerCompletions.count
@@ -572,7 +572,7 @@ public class Request: @unchecked Sendable {
     func processNextResponseSerializer() {
         guard let responseSerializer = nextResponseSerializer() else {
             // Execute all response serializer completions and clear them
-            var completions: [@Sendable () -> Void] = []
+            var completions: [() -> sending Void] = []
 
             mutableState.write { mutableState in
                 completions = mutableState.responseSerializerCompletions
@@ -607,7 +607,7 @@ public class Request: @unchecked Sendable {
     ///
     /// - Parameter completion: The completion handler provided with the response serializer, called when all serializers
     ///                         are complete.
-    func responseSerializerDidComplete(completion: @escaping @Sendable () -> Void) {
+    func responseSerializerDidComplete(completion: @escaping  () -> sending Void) {
         mutableState.write { $0.responseSerializerCompletions.append(completion) }
         processNextResponseSerializer()
     }
@@ -642,7 +642,7 @@ public class Request: @unchecked Sendable {
     /// Perform a closure on the current `state` while locked.
     ///
     /// - Parameter perform: The closure to perform.
-    func withState(perform: (State) -> Void) {
+    func withState(perform: (State) -> sending Void) {
         mutableState.withState(perform: perform)
     }
 
@@ -655,7 +655,7 @@ public class Request: @unchecked Sendable {
     ///   - session: `URLSession` which creates the `URLSessionTask`.
     ///
     /// - Returns:   The `URLSessionTask` created.
-    func task(for request: URLRequest, using session: URLSession) -> URLSessionTask {
+    func task(for request: URLRequest, using session: URLSession) -> sending URLSessionTask {
         fatalError("Subclasses must override.")
     }
 
@@ -669,7 +669,7 @@ public class Request: @unchecked Sendable {
     ///
     /// - Returns: The instance.
     @discardableResult
-    public func cancel() -> Self {
+    public func cancel() -> sending Self {
         mutableState.write { mutableState in
             guard mutableState.state.canTransitionTo(.cancelled) else { return }
 
@@ -695,7 +695,7 @@ public class Request: @unchecked Sendable {
     ///
     /// - Returns: The instance.
     @discardableResult
-    public func suspend() -> Self {
+    public func suspend() -> sending Self {
         mutableState.write { mutableState in
             guard mutableState.state.canTransitionTo(.suspended) else { return }
 
@@ -716,7 +716,7 @@ public class Request: @unchecked Sendable {
     ///
     /// - Returns: The instance.
     @discardableResult
-    public func resume() -> Self {
+    public func resume() -> sending Self {
         mutableState.write { mutableState in
             guard mutableState.state.canTransitionTo(.resumed) else { return }
 
@@ -744,7 +744,7 @@ public class Request: @unchecked Sendable {
     ///
     /// - Returns:       The instance.
     @discardableResult
-    public func authenticate(username: String, password: String, persistence: URLCredential.Persistence = .forSession) -> Self {
+    public func authenticate(username: String, password: String, persistence: URLCredential.Persistence = .forSession) -> sending Self {
         let credential = URLCredential(user: username, password: password, persistence: persistence)
 
         return authenticate(with: credential)
@@ -756,7 +756,7 @@ public class Request: @unchecked Sendable {
     ///
     /// - Returns:              The instance.
     @discardableResult
-    public func authenticate(with credential: URLCredential) -> Self {
+    public func authenticate(with credential: URLCredential) -> sending Self {
         mutableState.credential = credential
 
         return self
@@ -773,7 +773,7 @@ public class Request: @unchecked Sendable {
     /// - Returns:   The instance.
     @preconcurrency
     @discardableResult
-    public func downloadProgress(queue: DispatchQueue = .main, closure: @escaping ProgressHandler) -> Self {
+    public func downloadProgress(queue: DispatchQueue = .main, closure: @escaping ProgressHandler) -> sending Self {
         mutableState.downloadProgressHandler = (handler: closure, queue: queue)
 
         return self
@@ -790,7 +790,7 @@ public class Request: @unchecked Sendable {
     /// - Returns:   The instance.
     @preconcurrency
     @discardableResult
-    public func uploadProgress(queue: DispatchQueue = .main, closure: @escaping ProgressHandler) -> Self {
+    public func uploadProgress(queue: DispatchQueue = .main, closure: @escaping ProgressHandler) -> sending Self {
         mutableState.uploadProgressHandler = (handler: closure, queue: queue)
 
         return self
@@ -807,7 +807,7 @@ public class Request: @unchecked Sendable {
     /// - Returns:           The instance.
     @preconcurrency
     @discardableResult
-    public func redirect(using handler: any RedirectHandler) -> Self {
+    public func redirect(using handler: any RedirectHandler) -> sending Self {
         mutableState.write { mutableState in
             precondition(mutableState.redirectHandler == nil, "Redirect handler has already been set.")
             mutableState.redirectHandler = handler
@@ -827,7 +827,7 @@ public class Request: @unchecked Sendable {
     /// - Returns:           The instance.
     @preconcurrency
     @discardableResult
-    public func cacheResponse(using handler: any CachedResponseHandler) -> Self {
+    public func cacheResponse(using handler: any CachedResponseHandler) -> sending Self {
         mutableState.write { mutableState in
             precondition(mutableState.cachedResponseHandler == nil, "Cached response handler has already been set.")
             mutableState.cachedResponseHandler = handler
@@ -849,7 +849,7 @@ public class Request: @unchecked Sendable {
     /// - Returns:           The instance.
     @preconcurrency
     @discardableResult
-    public func cURLDescription(on queue: DispatchQueue, calling handler: @escaping @Sendable (String) -> Void) -> Self {
+    public func cURLDescription(on queue: DispatchQueue, calling handler: @escaping  (String) -> sending Void) -> Self {
         mutableState.write { mutableState in
             if mutableState.requests.last != nil {
                 queue.async { handler(self.cURLDescription()) }
@@ -871,7 +871,7 @@ public class Request: @unchecked Sendable {
     /// - Returns:           The instance.
     @preconcurrency
     @discardableResult
-    public func cURLDescription(calling handler: @escaping @Sendable (String) -> Void) -> Self {
+    public func cURLDescription(calling handler: @escaping  (String) -> sending Void) -> Self {
         cURLDescription(on: underlyingQueue, calling: handler)
 
         return self
@@ -888,7 +888,7 @@ public class Request: @unchecked Sendable {
     /// - Returns:   The instance.
     @preconcurrency
     @discardableResult
-    public func onURLRequestCreation(on queue: DispatchQueue = .main, perform handler: @escaping @Sendable (URLRequest) -> Void) -> Self {
+    public func onURLRequestCreation(on queue: DispatchQueue = .main, perform handler: @escaping  (URLRequest) -> sending Void) -> Self {
         mutableState.write { state in
             if let request = state.requests.last {
                 queue.async { handler(request) }
@@ -913,7 +913,7 @@ public class Request: @unchecked Sendable {
     /// - Returns:   The instance.
     @preconcurrency
     @discardableResult
-    public func onURLSessionTaskCreation(on queue: DispatchQueue = .main, perform handler: @escaping @Sendable (URLSessionTask) -> Void) -> Self {
+    public func onURLSessionTaskCreation(on queue: DispatchQueue = .main, perform handler: @escaping  (URLSessionTask) -> sending Void) -> Self {
         mutableState.write { state in
             if let task = state.tasks.last {
                 queue.async { handler(task) }
@@ -930,7 +930,7 @@ public class Request: @unchecked Sendable {
     /// Adds a `finishHandler` closure to be called when the request completes.
     ///
     /// - Parameter closure: Closure to be called when the request finishes.
-    func onFinish(perform finishHandler: @escaping () -> Void) {
+    func onFinish(perform finishHandler: @escaping () -> sending Void) {
         guard !isFinished else { finishHandler(); return }
 
         mutableState.write { state in
@@ -970,7 +970,7 @@ extension Request {
 // MARK: - Protocol Conformances
 
 extension Request: Equatable {
-    public static func ==(lhs: Request, rhs: Request) -> Bool {
+    public static func ==(lhs: Request, rhs: Request) -> sending Bool {
         lhs.id == rhs.id
     }
 }
@@ -999,7 +999,7 @@ extension Request {
     /// cURL representation of the instance.
     ///
     /// - Returns: The cURL equivalent of the instance.
-    public func cURLDescription() -> String {
+    public func cURLDescription() -> sending String {
         guard
             let request = lastRequest,
             let url = request.url,
@@ -1089,7 +1089,7 @@ public protocol RequestDelegate: AnyObject, Sendable {
     ///   - request:    `Request` which failed.
     ///   - error:      `Error` which produced the failure.
     ///   - completion: Closure taking the `RetryResult` for evaluation.
-    func retryResult(for request: Request, dueTo error: AFError, completion: @escaping @Sendable (RetryResult) -> Void)
+    func retryResult(for request: Request, dueTo error: AFError, completion: @escaping  (RetryResult) -> sending Void)
 
     /// Asynchronously retry the `Request`.
     ///

--- a/Source/Core/Session.swift
+++ b/Source/Core/Session.swift
@@ -72,7 +72,7 @@ open class Session: @unchecked Sendable {
     /// `Set` of currently active `Request`s.
     var activeRequests: Set<Request> = []
     /// Completion events awaiting `URLSessionTaskMetrics`.
-    var waitingCompletions: [URLSessionTask: () -> Void] = [:]
+    var waitingCompletions: [URLSessionTask:() -> sending Void] = [:]
 
     /// Creates a `Session` from a `URLSession` and other parameters.
     ///
@@ -217,7 +217,7 @@ open class Session: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - action:     Closure to perform with all `Request`s.
-    public func withAllRequests(perform action: @escaping @Sendable (Set<Request>) -> Void) {
+    public func withAllRequests(perform action: @escaping  (Set<Request>) -> sending Void) {
         rootQueue.async {
             action(self.activeRequests)
         }
@@ -232,7 +232,7 @@ open class Session: @unchecked Sendable {
     /// - Parameters:
     ///   - queue:      `DispatchQueue` on which the completion handler is run. `.main` by default.
     ///   - completion: Closure to be called when all `Request`s have been cancelled.
-    public func cancelAllRequests(completingOnQueue queue: DispatchQueue = .main, completion: (@Sendable () -> Void)? = nil) {
+    public func cancelAllRequests(completingOnQueue queue: DispatchQueue = .main, completion: ( () -> sending Void)? = nil) {
         withAllRequests { requests in
             requests.forEach { $0.cancel() }
             queue.async {
@@ -244,7 +244,7 @@ open class Session: @unchecked Sendable {
     // MARK: - DataRequest
 
     /// Closure which provides a `URLRequest` for mutation.
-    public typealias RequestModifier = @Sendable (inout URLRequest) throws -> Void
+    public typealias RequestModifier = (inout URLRequest) throws -> sending Void
 
     struct RequestConvertible: URLRequestConvertible {
         let url: any URLConvertible
@@ -254,7 +254,7 @@ open class Session: @unchecked Sendable {
         let headers: HTTPHeaders?
         let requestModifier: RequestModifier?
 
-        func asURLRequest() throws -> URLRequest {
+        func asURLRequest() throws -> sending URLRequest {
             var request = try URLRequest(url: url, method: method, headers: headers)
             try requestModifier?(&request)
 
@@ -302,7 +302,7 @@ open class Session: @unchecked Sendable {
         let headers: HTTPHeaders?
         let requestModifier: RequestModifier?
 
-        func asURLRequest() throws -> URLRequest {
+        func asURLRequest() throws -> sending URLRequest {
             var request = try URLRequest(url: url, method: method, headers: headers)
             try requestModifier?(&request)
 
@@ -667,7 +667,7 @@ open class Session: @unchecked Sendable {
         let headers: HTTPHeaders?
         let requestModifier: RequestModifier?
 
-        func asURLRequest() throws -> URLRequest {
+        func asURLRequest() throws -> sending URLRequest {
             var request = try URLRequest(url: url, method: method, headers: headers)
             try requestModifier?(&request)
 
@@ -679,11 +679,11 @@ open class Session: @unchecked Sendable {
         let request: any URLRequestConvertible
         let uploadable: any UploadableConvertible
 
-        func createUploadable() throws -> UploadRequest.Uploadable {
+        func createUploadable() throws -> sending UploadRequest.Uploadable {
             try uploadable.createUploadable()
         }
 
-        func asURLRequest() throws -> URLRequest {
+        func asURLRequest() throws -> sending URLRequest {
             try request.asURLRequest()
         }
     }
@@ -869,7 +869,7 @@ open class Session: @unchecked Sendable {
     ///                              provided parameters. `nil` by default.
     ///
     /// - Returns:                   The created `UploadRequest`.
-    open func upload(multipartFormData: @escaping (MultipartFormData) -> Void,
+    open func upload(multipartFormData: @escaping (MultipartFormData) -> sending Void,
                      to url: any URLConvertible,
                      usingThreshold encodingMemoryThreshold: UInt64 = MultipartFormData.encodingMemoryThreshold,
                      method: HTTPMethod = .post,
@@ -919,7 +919,7 @@ open class Session: @unchecked Sendable {
     ///                              written to disk before being uploaded. `.default` instance by default.
     ///
     /// - Returns:                   The created `UploadRequest`.
-    open func upload(multipartFormData: @escaping (MultipartFormData) -> Void,
+    open func upload(multipartFormData: @escaping (MultipartFormData) -> sending Void,
                      with request: any URLRequestConvertible,
                      usingThreshold encodingMemoryThreshold: UInt64 = MultipartFormData.encodingMemoryThreshold,
                      interceptor: (any RequestInterceptor)? = nil,
@@ -1134,7 +1134,7 @@ open class Session: @unchecked Sendable {
 
     func performSetupOperations(for request: Request,
                                 convertible: any URLRequestConvertible,
-                                shouldCreateTask: @escaping @Sendable () -> Bool = { true }) {
+                                shouldCreateTask: @escaping  () -> sending Bool = { true }) {
         dispatchPrecondition(condition: .onQueue(requestQueue))
 
         let initialRequest: URLRequest
@@ -1228,7 +1228,7 @@ open class Session: @unchecked Sendable {
 
     // MARK: - Adapters and Retriers
 
-    func adapter(for request: Request) -> (any RequestAdapter)? {
+    func adapter(for request: Request) -> sending (any RequestAdapter)? {
         if let requestInterceptor = request.interceptor, let sessionInterceptor = interceptor {
             Interceptor(adapters: [requestInterceptor, sessionInterceptor])
         } else {
@@ -1236,7 +1236,7 @@ open class Session: @unchecked Sendable {
         }
     }
 
-    func retrier(for request: Request) -> (any RequestRetrier)? {
+    func retrier(for request: Request) -> sending (any RequestRetrier)? {
         if let requestInterceptor = request.interceptor, let sessionInterceptor = interceptor {
             Interceptor(retriers: [requestInterceptor, sessionInterceptor])
         } else {
@@ -1268,7 +1268,7 @@ extension Session: RequestDelegate {
         activeRequests.remove(request)
     }
 
-    public func retryResult(for request: Request, dueTo error: AFError, completion: @escaping @Sendable (RetryResult) -> Void) {
+    public func retryResult(for request: Request, dueTo error: AFError, completion: @escaping  (RetryResult) -> sending Void) {
         guard let retrier = retrier(for: request) else {
             rootQueue.async { completion(.doNotRetry) }
             return
@@ -1286,7 +1286,7 @@ extension Session: RequestDelegate {
 
     public func retryRequest(_ request: Request, withDelay timeDelay: TimeInterval?) {
         rootQueue.async {
-            let retry: @Sendable () -> Void = {
+            let retry: () -> sending Void = {
                 guard !request.isCancelled else { return }
 
                 request.prepareForRetry()
@@ -1305,7 +1305,7 @@ extension Session: RequestDelegate {
 // MARK: - SessionStateProvider
 
 extension Session: SessionStateProvider {
-    func request(for task: URLSessionTask) -> Request? {
+    func request(for task: URLSessionTask) -> sending Request? {
         dispatchPrecondition(condition: .onQueue(rootQueue))
 
         return requestTaskMap[task]
@@ -1322,7 +1322,7 @@ extension Session: SessionStateProvider {
         }
     }
 
-    func didCompleteTask(_ task: URLSessionTask, completion: @escaping () -> Void) {
+    func didCompleteTask(_ task: URLSessionTask, completion: @escaping () -> sending Void) {
         dispatchPrecondition(condition: .onQueue(rootQueue))
 
         let didDisassociate = requestTaskMap.disassociateIfNecessaryAfterCompletingTask(task)
@@ -1334,7 +1334,7 @@ extension Session: SessionStateProvider {
         }
     }
 
-    func credential(for task: URLSessionTask, in protectionSpace: URLProtectionSpace) -> URLCredential? {
+    func credential(for task: URLSessionTask, in protectionSpace: URLProtectionSpace) -> sending URLCredential? {
         dispatchPrecondition(condition: .onQueue(rootQueue))
 
         return requestTaskMap[task]?.credential ??

--- a/Source/Core/SessionDelegate.swift
+++ b/Source/Core/SessionDelegate.swift
@@ -44,7 +44,7 @@ open class SessionDelegate: NSObject, @unchecked Sendable {
     /// - Parameters:
     ///   - task: The `URLSessionTask` for which to find the associated `Request`.
     ///   - type: The `Request` subclass type to cast any `Request` associate with `task`.
-    func request<R: Request>(for task: URLSessionTask, as type: R.Type) -> R? {
+    func request<R: Request>(for task: URLSessionTask, as type: R.Type) -> sending R? {
         guard let provider = stateProvider else {
             assertionFailure("StateProvider is nil for task \(task.taskIdentifier).")
             return nil
@@ -60,10 +60,10 @@ protocol SessionStateProvider: AnyObject, Sendable {
     var redirectHandler: (any RedirectHandler)? { get }
     var cachedResponseHandler: (any CachedResponseHandler)? { get }
 
-    func request(for task: URLSessionTask) -> Request?
+    func request(for task: URLSessionTask) -> sending Request?
     func didGatherMetricsForTask(_ task: URLSessionTask)
-    func didCompleteTask(_ task: URLSessionTask, completion: @escaping () -> Void)
-    func credential(for task: URLSessionTask, in protectionSpace: URLProtectionSpace) -> URLCredential?
+    func didCompleteTask(_ task: URLSessionTask, completion: @escaping () -> sending Void)
+    func credential(for task: URLSessionTask, in protectionSpace: URLProtectionSpace) -> sending URLCredential?
     func cancelRequestsForSessionInvalidation(with error: (any Error)?)
 }
 
@@ -86,7 +86,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
     open func urlSession(_ session: URLSession,
                          task: URLSessionTask,
                          didReceive challenge: URLAuthenticationChallenge,
-                         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+                         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> sending Void) {
         eventMonitor?.urlSession(session, task: task, didReceive: challenge)
 
         let evaluation: ChallengeEvaluation
@@ -117,7 +117,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
     /// - Parameter challenge: The `URLAuthenticationChallenge`.
     ///
     /// - Returns:             The `ChallengeEvaluation`.
-    func attemptServerTrustAuthentication(with challenge: URLAuthenticationChallenge) -> ChallengeEvaluation {
+    func attemptServerTrustAuthentication(with challenge: URLAuthenticationChallenge) -> sending ChallengeEvaluation {
         let host = challenge.protectionSpace.host
 
         guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
@@ -148,7 +148,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
     ///
     /// - Returns:     The `ChallengeEvaluation`.
     func attemptCredentialAuthentication(for challenge: URLAuthenticationChallenge,
-                                         belongingTo task: URLSessionTask) -> ChallengeEvaluation {
+                                         belongingTo task: URLSessionTask) -> sending ChallengeEvaluation {
         guard challenge.previousFailureCount == 0 else {
             return (.rejectProtectionSpace, nil, nil)
         }
@@ -177,7 +177,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
 
     open func urlSession(_ session: URLSession,
                          task: URLSessionTask,
-                         needNewBodyStream completionHandler: @escaping (InputStream?) -> Void) {
+                         needNewBodyStream completionHandler: @escaping (InputStream?) -> sending Void) {
         eventMonitor?.urlSession(session, taskNeedsNewBodyStream: task)
 
         guard let request = request(for: task, as: UploadRequest.self) else {
@@ -193,7 +193,7 @@ extension SessionDelegate: URLSessionTaskDelegate {
                          task: URLSessionTask,
                          willPerformHTTPRedirection response: HTTPURLResponse,
                          newRequest request: URLRequest,
-                         completionHandler: @escaping (URLRequest?) -> Void) {
+                         completionHandler: @escaping (URLRequest?) -> sending Void) {
         eventMonitor?.urlSession(session, task: task, willPerformHTTPRedirection: response, newRequest: request)
 
         if let redirectHandler = stateProvider?.request(for: task)?.redirectHandler ?? stateProvider?.redirectHandler {
@@ -234,7 +234,7 @@ extension SessionDelegate: URLSessionDataDelegate {
     open func urlSession(_ session: URLSession,
                          dataTask: URLSessionDataTask,
                          didReceive response: URLResponse,
-                         completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void) {
+                         completionHandler: @escaping  (URLSession.ResponseDisposition) -> sending Void) {
         eventMonitor?.urlSession(session, dataTask: dataTask, didReceive: response)
 
         guard let response = response as? HTTPURLResponse else { completionHandler(.allow); return }
@@ -266,7 +266,7 @@ extension SessionDelegate: URLSessionDataDelegate {
     open func urlSession(_ session: URLSession,
                          dataTask: URLSessionDataTask,
                          willCacheResponse proposedResponse: CachedURLResponse,
-                         completionHandler: @escaping (CachedURLResponse?) -> Void) {
+                         completionHandler: @escaping (CachedURLResponse?) -> sending Void) {
         eventMonitor?.urlSession(session, dataTask: dataTask, willCacheResponse: proposedResponse)
 
         if let handler = stateProvider?.request(for: dataTask)?.cachedResponseHandler ?? stateProvider?.cachedResponseHandler {

--- a/Source/Core/UploadRequest.swift
+++ b/Source/Core/UploadRequest.swift
@@ -104,7 +104,7 @@ public final class UploadRequest: DataRequest, @unchecked Sendable {
         retryOrFinish(error: error)
     }
 
-    override func task(for request: URLRequest, using session: URLSession) -> URLSessionTask {
+    override func task(for request: URLRequest, using session: URLSession) -> sending URLSessionTask {
         guard let uploadable else {
             fatalError("Attempting to create a URLSessionUploadTask when Uploadable value doesn't exist.")
         }

--- a/Source/Core/WebSocketRequest.swift
+++ b/Source/Core/WebSocketRequest.swift
@@ -72,7 +72,7 @@ import Foundation
             socket?.cancel()
         }
 
-        public func sendPing(respondingOn queue: DispatchQueue = .main, onResponse: @escaping @Sendable (PingResponse) -> Void) {
+        public func sendPing(respondingOn queue: DispatchQueue = .main, onResponse: @escaping  (PingResponse) -> sending Void) {
             socket?.sendPing(respondingOn: queue, onResponse: onResponse)
         }
     }
@@ -91,15 +91,15 @@ import Foundation
     public struct Configuration {
         public static var `default`: Self { Self() }
 
-        public static func `protocol`(_ protocol: String) -> Self {
+        public static func `protocol`(_ protocol: String) -> sending Self {
             Self(protocol: `protocol`)
         }
 
-        public static func maximumMessageSize(_ maximumMessageSize: Int) -> Self {
+        public static func maximumMessageSize(_ maximumMessageSize: Int) -> sending Self {
             Self(maximumMessageSize: maximumMessageSize)
         }
 
-        public static func pingInterval(_ pingInterval: TimeInterval) -> Self {
+        public static func pingInterval(_ pingInterval: TimeInterval) -> sending Self {
             Self(pingInterval: pingInterval)
         }
 
@@ -133,8 +133,8 @@ import Foundation
     struct SocketMutableState {
         var enqueuedSends: [(message: URLSessionWebSocketTask.Message,
                              queue: DispatchQueue,
-                             completionHandler: @Sendable (Result<Void, any Error>) -> Void)] = []
-        var handlers: [(queue: DispatchQueue, handler: (_ event: IncomingEvent) -> Void)] = []
+                             completionHandler:  (Result<Void, any Error>) -> sending Void)] = []
+        var handlers: [(queue: DispatchQueue, handler: (_ event: IncomingEvent) -> sending Void)] = []
         var pingTimerItem: DispatchWorkItem?
     }
 
@@ -166,7 +166,7 @@ import Foundation
                    delegate: delegate)
     }
 
-    override func task(for request: URLRequest, using session: URLSession) -> URLSessionTask {
+    override func task(for request: URLRequest, using session: URLSession) -> sending URLSessionTask {
         var copiedRequest = request
         let task: URLSessionWebSocketTask
         if let `protocol` = configuration.protocol {
@@ -225,7 +225,7 @@ import Foundation
     }
 
     @discardableResult
-    public func close(sending closeCode: URLSessionWebSocketTask.CloseCode, reason: Data? = nil) -> Self {
+    public func close(sending closeCode: URLSessionWebSocketTask.CloseCode, reason: Data? = nil) -> sending Self {
         cancelAutomaticPing()
 
         mutableState.write { mutableState in
@@ -251,7 +251,7 @@ import Foundation
     }
 
     @discardableResult
-    override public func cancel() -> Self {
+    override public func cancel() -> sending Self {
         cancelAutomaticPing()
 
         return super.cancel()
@@ -274,7 +274,7 @@ import Foundation
     }
 
     @preconcurrency
-    public func sendPing(respondingOn queue: DispatchQueue = .main, onResponse: @escaping @Sendable (PingResponse) -> Void) {
+    public func sendPing(respondingOn queue: DispatchQueue = .main, onResponse: @escaping  (PingResponse) -> sending Void) {
         guard isResumed else {
             queue.async { onResponse(.unsent) }
             return
@@ -375,7 +375,7 @@ import Foundation
     public func streamSerializer<Serializer>(
         _ serializer: Serializer,
         on queue: DispatchQueue = .main,
-        handler: @escaping @Sendable (_ event: Event<Serializer.Output, Serializer.Failure>) -> Void
+        handler: @escaping  (_ event: Event<Serializer.Output, Serializer.Failure>) -> sending Void
     ) -> Self where Serializer: WebSocketMessageSerializer, Serializer.Failure == any Error {
         forIncomingEvent(on: queue) { incomingEvent in
             let event: Event<Serializer.Output, Serializer.Failure>
@@ -405,7 +405,7 @@ import Foundation
         _ type: Value.Type = Value.self,
         on queue: DispatchQueue = .main,
         using decoder: any DataDecoder = JSONDecoder(),
-        handler: @escaping @Sendable (_ event: Event<Value, any Error>) -> Void
+        handler: @escaping (_ event: Event<Value, any Error>) -> sending Void
     ) -> Self where Value: Decodable {
         streamSerializer(DecodableWebSocketMessageDecoder<Value>(decoder: decoder), on: queue, handler: handler)
     }
@@ -416,7 +416,7 @@ import Foundation
         _ type: Value.Type = Value.self,
         on queue: DispatchQueue = .main,
         using decoder: any DataDecoder = JSONDecoder(),
-        handler: @escaping @Sendable (_ value: Value) -> Void
+        handler: @escaping (_ value: Value) -> sending Void
     ) -> Self where Value: Decodable & Sendable {
         streamDecodableEvents(Value.self, on: queue) { event in
             event.message.map(handler)
@@ -427,7 +427,7 @@ import Foundation
     @discardableResult
     public func streamMessageEvents(
         on queue: DispatchQueue = .main,
-        handler: @escaping @Sendable (_ event: Event<URLSessionWebSocketTask.Message, Never>) -> Void
+        handler: @escaping  (_ event: Event<URLSessionWebSocketTask.Message, Never>) -> sending Void
     ) -> Self {
         forIncomingEvent(on: queue) { incomingEvent in
             let event: Event<URLSessionWebSocketTask.Message, Never> = switch incomingEvent {
@@ -449,14 +449,14 @@ import Foundation
     @discardableResult
     public func streamMessages(
         on queue: DispatchQueue = .main,
-        handler: @escaping @Sendable (_ message: URLSessionWebSocketTask.Message) -> Void
+        handler: @escaping  (_ message: URLSessionWebSocketTask.Message) -> sending Void
     ) -> Self {
         streamMessageEvents(on: queue) { event in
             event.message.map(handler)
         }
     }
 
-    func forIncomingEvent(on queue: DispatchQueue, handler: @escaping @Sendable (IncomingEvent) -> Void) -> Self {
+    func forIncomingEvent(on queue: DispatchQueue, handler: @escaping  (IncomingEvent) -> sending Void) -> Self {
         socketMutableState.write { state in
             state.handlers.append((queue: queue, handler: { incomingEvent in
                 self.serializationQueue.async {
@@ -482,7 +482,7 @@ import Foundation
     @preconcurrency
     public func send(_ message: URLSessionWebSocketTask.Message,
                      queue: DispatchQueue = .main,
-                     completionHandler: @escaping @Sendable (Result<Void, any Error>) -> Void) {
+                     completionHandler: @escaping  (Result<Void, any Error>) -> sending Void) {
         guard !(isCancelled || isFinished) else { return }
 
         guard let socket else {
@@ -507,7 +507,7 @@ public protocol WebSocketMessageSerializer<Output, Failure>: Sendable {
     associatedtype Output: Sendable
     associatedtype Failure: Error = any Error
 
-    func decode(_ message: URLSessionWebSocketTask.Message) throws -> Output
+    func decode(_ message: URLSessionWebSocketTask.Message) throws -> sending Output
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
@@ -528,7 +528,7 @@ extension WebSocketMessageSerializer {
 struct PassthroughWebSocketMessageDecoder: WebSocketMessageSerializer {
     public typealias Failure = Never
 
-    public func decode(_ message: URLSessionWebSocketTask.Message) -> URLSessionWebSocketTask.Message {
+    public func decode(_ message: URLSessionWebSocketTask.Message) -> sending URLSessionWebSocketTask.Message {
         message
     }
 }
@@ -546,7 +546,7 @@ public struct DecodableWebSocketMessageDecoder<Value: Decodable & Sendable>: Web
         self.decoder = decoder
     }
 
-    public func decode(_ message: URLSessionWebSocketTask.Message) throws -> Value {
+    public func decode(_ message: URLSessionWebSocketTask.Message) throws -> sending Value {
         let data: Data
         switch message {
         case let .data(messageData):

--- a/Source/Extensions/DispatchQueue+Alamofire.swift
+++ b/Source/Extensions/DispatchQueue+Alamofire.swift
@@ -31,7 +31,7 @@ extension DispatchQueue {
     /// - Parameters:
     ///   - delay:   `TimeInterval` to delay execution.
     ///   - closure: Closure to execute.
-    func after(_ delay: TimeInterval, execute closure: @escaping @Sendable () -> Void) {
+    func after(_ delay: TimeInterval, execute closure: @escaping  () -> sending Void) {
         asyncAfter(deadline: .now() + delay, execute: closure)
     }
 }

--- a/Source/Features/AuthenticationInterceptor.swift
+++ b/Source/Features/AuthenticationInterceptor.swift
@@ -81,7 +81,7 @@ public protocol Authenticator: AnyObject, Sendable {
     ///   - credential: The `Credential` to refresh.
     ///   - session:    The `Session` requiring the refresh.
     ///   - completion: The closure to be executed once the refresh is complete.
-    func refresh(_ credential: Credential, for session: Session, completion: @escaping @Sendable (Result<Credential, any Error>) -> Void)
+    func refresh(_ credential: Credential, for session: Session, completion: @escaping  (Result<Credential, any Error>) -> sending Void)
 
     /// Determines whether the `URLRequest` failed due to an authentication error based on the `HTTPURLResponse`.
     ///
@@ -106,7 +106,7 @@ public protocol Authenticator: AnyObject, Sendable {
     ///   - error:      The `Error`.
     ///
     /// - Returns: `true` if the `URLRequest` failed due to an authentication error, `false` otherwise.
-    func didRequest(_ urlRequest: URLRequest, with response: HTTPURLResponse, failDueToAuthenticationError error: any Error) -> Bool
+    func didRequest(_ urlRequest: URLRequest, with response: HTTPURLResponse, failDueToAuthenticationError error: any Error) -> sending Bool
 
     /// Determines whether the `URLRequest` is authenticated with the `Credential`.
     ///
@@ -138,7 +138,7 @@ public protocol Authenticator: AnyObject, Sendable {
     ///   - credential: The `Credential`.
     ///
     /// - Returns: `true` if the `URLRequest` is authenticated with the `Credential`, `false` otherwise.
-    func isRequest(_ urlRequest: URLRequest, authenticatedWith credential: Credential) -> Bool
+    func isRequest(_ urlRequest: URLRequest, authenticatedWith credential: Credential) -> sending Bool
 }
 
 // MARK: -
@@ -193,7 +193,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
     private struct AdaptOperation {
         let urlRequest: URLRequest
         let session: Session
-        let completion: @Sendable (Result<URLRequest, any Error>) -> Void
+        let completion: (Result<URLRequest, any Error>) -> sending Void
     }
 
     private enum AdaptResult {
@@ -210,7 +210,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
         var refreshWindow: RefreshWindow?
 
         var adaptOperations: [AdaptOperation] = []
-        var requestsToRetry: [@Sendable (RetryResult) -> Void] = []
+        var requestsToRetry: [(RetryResult) -> sending Void] = []
     }
 
     // MARK: Properties
@@ -246,7 +246,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
 
     // MARK: Adapt
 
-    public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
+    public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping  (Result<URLRequest, any Error>) -> sending Void) {
         let adaptResult: AdaptResult = mutableState.write { mutableState in
             // Queue the adapt operation if a refresh is already in place.
             guard !mutableState.isRefreshing else {
@@ -289,7 +289,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
 
     // MARK: Retry
 
-    public func retry(_ request: Request, for session: Session, dueTo error: any Error, completion: @escaping @Sendable (RetryResult) -> Void) {
+    public func retry(_ request: Request, for session: Session, dueTo error: any Error, completion: @escaping  (RetryResult) -> sending Void) {
         // Do not attempt retry if there was not an original request and response from the server.
         guard let urlRequest = request.request, let response = request.response else {
             completion(.doNotRetry)
@@ -351,7 +351,7 @@ public final class AuthenticationInterceptor<AuthenticatorType>: RequestIntercep
         }
     }
 
-    private func isRefreshExcessive(insideLock mutableState: inout MutableState) -> Bool {
+    private func isRefreshExcessive(insideLock mutableState: inout MutableState) -> sending Bool {
         guard let refreshWindow = mutableState.refreshWindow else { return false }
 
         let refreshWindowMin = ProcessInfo.processInfo.systemUptime - refreshWindow.interval

--- a/Source/Features/CachedResponseHandler.swift
+++ b/Source/Features/CachedResponseHandler.swift
@@ -40,7 +40,7 @@ public protocol CachedResponseHandler: Sendable {
     ///   - completion: The closure to execute containing cached response, a modified response, or `nil`.
     func dataTask(_ task: URLSessionDataTask,
                   willCacheResponse response: CachedURLResponse,
-                  completion: @escaping (CachedURLResponse?) -> Void)
+                  completion: @escaping (CachedURLResponse?) -> sending Void)
 }
 
 // MARK: -
@@ -55,7 +55,7 @@ public struct ResponseCacher {
         /// Prevents the cached response from being stored in the cache.
         case doNotCache
         /// Modifies the cached response before storing it in the cache.
-        case modify(@Sendable (_ task: URLSessionDataTask, _ cachedResponse: CachedURLResponse) -> CachedURLResponse?)
+        case modify( (_ task: URLSessionDataTask, _ cachedResponse: CachedURLResponse) -> sending CachedURLResponse?)
     }
 
     /// Returns a `ResponseCacher` with a `.cache` `Behavior`.
@@ -77,7 +77,7 @@ public struct ResponseCacher {
 extension ResponseCacher: CachedResponseHandler {
     public func dataTask(_ task: URLSessionDataTask,
                          willCacheResponse response: CachedURLResponse,
-                         completion: @escaping (CachedURLResponse?) -> Void) {
+                         completion: @escaping (CachedURLResponse?) -> sending Void) {
         switch behavior {
         case .cache:
             completion(response)
@@ -101,7 +101,7 @@ extension CachedResponseHandler where Self == ResponseCacher {
     ///
     /// - Parameter closure: Closure used to modify the `CachedURLResponse`.
     /// - Returns:           The `ResponseCacher`.
-    public static func modify(using closure: @escaping (@Sendable (URLSessionDataTask, CachedURLResponse) -> CachedURLResponse?)) -> ResponseCacher {
+    public static func modify(using closure: @escaping ( (URLSessionDataTask, CachedURLResponse) -> sending CachedURLResponse?)) -> ResponseCacher {
         ResponseCacher(behavior: .modify(closure))
     }
 }

--- a/Source/Features/Combine.swift
+++ b/Source/Features/Combine.swift
@@ -36,7 +36,7 @@ public struct DataResponsePublisher<Value: Sendable>: Publisher {
     public typealias Output = DataResponse<Value, AFError>
     public typealias Failure = Never
 
-    private typealias Handler = (@escaping @Sendable (_ response: DataResponse<Value, AFError>) -> Void) -> DataRequest
+    private typealias Handler = (@escaping (_ response: DataResponse<Value, AFError>) -> sending Void) -> DataRequest
 
     private let request: DataRequest
     private let responseHandler: Handler
@@ -404,7 +404,7 @@ public struct DownloadResponsePublisher<Value: Sendable>: Publisher {
     public typealias Output = DownloadResponse<Value, AFError>
     public typealias Failure = Never
 
-    private typealias Handler = (@escaping @Sendable (_ response: DownloadResponse<Value, AFError>) -> Void) -> DownloadRequest
+    private typealias Handler = (@escaping (_ response: DownloadResponse<Value, AFError>) -> sending Void) -> DownloadRequest
 
     private let request: DownloadRequest
     private let responseHandler: Handler

--- a/Source/Features/Concurrency.swift
+++ b/Source/Features/Concurrency.swift
@@ -35,7 +35,7 @@ extension Request {
     /// - Parameter bufferingPolicy: `BufferingPolicy` that determines the stream's buffering behavior.`.unbounded` by default.
     ///
     /// - Returns:                   The `StreamOf<Progress>`.
-    public func uploadProgress(bufferingPolicy: StreamOf<Progress>.BufferingPolicy = .unbounded) -> StreamOf<Progress> {
+    public func uploadProgress(bufferingPolicy: StreamOf<Progress>.BufferingPolicy = .unbounded) -> sending StreamOf<Progress> {
         stream(bufferingPolicy: bufferingPolicy) { [unowned self] continuation in
             uploadProgress(queue: underlyingQueue) { progress in
                 continuation.yield(progress)
@@ -48,7 +48,7 @@ extension Request {
     /// - Parameter bufferingPolicy: `BufferingPolicy` that determines the stream's buffering behavior.`.unbounded` by default.
     ///
     /// - Returns:                   The `StreamOf<Progress>`.
-    public func downloadProgress(bufferingPolicy: StreamOf<Progress>.BufferingPolicy = .unbounded) -> StreamOf<Progress> {
+    public func downloadProgress(bufferingPolicy: StreamOf<Progress>.BufferingPolicy = .unbounded) -> sending StreamOf<Progress> {
         stream(bufferingPolicy: bufferingPolicy) { [unowned self] continuation in
             downloadProgress(queue: underlyingQueue) { progress in
                 continuation.yield(progress)
@@ -61,7 +61,7 @@ extension Request {
     /// - Parameter bufferingPolicy: `BufferingPolicy` that determines the stream's buffering behavior.`.unbounded` by default.
     ///
     /// - Returns:                   The `StreamOf<URLRequest>`.
-    public func urlRequests(bufferingPolicy: StreamOf<URLRequest>.BufferingPolicy = .unbounded) -> StreamOf<URLRequest> {
+    public func urlRequests(bufferingPolicy: StreamOf<URLRequest>.BufferingPolicy = .unbounded) -> sending StreamOf<URLRequest> {
         stream(bufferingPolicy: bufferingPolicy) { [unowned self] continuation in
             onURLRequestCreation(on: underlyingQueue) { request in
                 continuation.yield(request)
@@ -74,7 +74,7 @@ extension Request {
     /// - Parameter bufferingPolicy: `BufferingPolicy` that determines the stream's buffering behavior.`.unbounded` by default.
     ///
     /// - Returns:                   The `StreamOf<URLSessionTask>`.
-    public func urlSessionTasks(bufferingPolicy: StreamOf<URLSessionTask>.BufferingPolicy = .unbounded) -> StreamOf<URLSessionTask> {
+    public func urlSessionTasks(bufferingPolicy: StreamOf<URLSessionTask>.BufferingPolicy = .unbounded) -> sending StreamOf<URLSessionTask> {
         stream(bufferingPolicy: bufferingPolicy) { [unowned self] continuation in
             onURLSessionTaskCreation(on: underlyingQueue) { task in
                 continuation.yield(task)
@@ -87,7 +87,7 @@ extension Request {
     /// - Parameter bufferingPolicy: `BufferingPolicy` that determines the stream's buffering behavior.`.unbounded` by default.
     ///
     /// - Returns:                   The `StreamOf<String>`.
-    public func cURLDescriptions(bufferingPolicy: StreamOf<String>.BufferingPolicy = .unbounded) -> StreamOf<String> {
+    public func cURLDescriptions(bufferingPolicy: StreamOf<String>.BufferingPolicy = .unbounded) -> sending StreamOf<String> {
         stream(bufferingPolicy: bufferingPolicy) { [unowned self] continuation in
             cURLDescription(on: underlyingQueue) { description in
                 continuation.yield(description)
@@ -97,7 +97,7 @@ extension Request {
 
     fileprivate func stream<T>(of type: T.Type = T.self,
                                bufferingPolicy: StreamOf<T>.BufferingPolicy = .unbounded,
-                               yielder: @escaping (StreamOf<T>.Continuation) -> Void) -> StreamOf<T> {
+                               yielder: @escaping (StreamOf<T>.Continuation) -> sending Void) -> StreamOf<T> {
         StreamOf<T>(bufferingPolicy: bufferingPolicy) { [unowned self] continuation in
             yielder(continuation)
             // Must come after serializers run in order to catch retry progress.
@@ -173,7 +173,7 @@ extension DataRequest {
     /// - Parameter bufferingPolicy: `BufferingPolicy` that determines the stream's buffering behavior.`.unbounded` by default.
     ///
     /// - Returns:                   The `StreamOf<HTTPURLResponse>`.
-    public func httpResponses(bufferingPolicy: StreamOf<HTTPURLResponse>.BufferingPolicy = .unbounded) -> StreamOf<HTTPURLResponse> {
+    public func httpResponses(bufferingPolicy: StreamOf<HTTPURLResponse>.BufferingPolicy = .unbounded) -> sending StreamOf<HTTPURLResponse> {
         stream(bufferingPolicy: bufferingPolicy) { [unowned self] continuation in
             onHTTPResponse(on: underlyingQueue) { response in
                 continuation.yield(response)
@@ -198,7 +198,7 @@ extension DataRequest {
     @_disfavoredOverload
     @discardableResult
     public func onHTTPResponse(
-        perform handler: @escaping @Sendable (_ response: HTTPURLResponse) async -> ResponseDisposition
+        perform handler: @escaping  (_ response: HTTPURLResponse) async -> sending ResponseDisposition
     ) -> Self {
         onHTTPResponse(on: underlyingQueue) { response, completionHandler in
             Task {
@@ -222,7 +222,7 @@ extension DataRequest {
     ///
     /// - Returns:   The instance.
     @discardableResult
-    public func onHTTPResponse(perform handler: @escaping @Sendable (_ response: HTTPURLResponse) async -> Void) -> Self {
+    public func onHTTPResponse(perform handler: @escaping  (_ response: HTTPURLResponse) async -> sending Void) -> Self {
         onHTTPResponse { response in
             await handler(response)
             return .allow
@@ -245,7 +245,7 @@ extension DataRequest {
     public func serializingData(automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
                                 dataPreprocessor: any DataPreprocessor = DataResponseSerializer.defaultDataPreprocessor,
                                 emptyResponseCodes: Set<Int> = DataResponseSerializer.defaultEmptyResponseCodes,
-                                emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods) -> DataTask<Data> {
+                                emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods) -> sending DataTask<Data> {
         serializingResponse(using: DataResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                           emptyResponseCodes: emptyResponseCodes,
                                                           emptyRequestMethods: emptyRequestMethods),
@@ -298,7 +298,7 @@ extension DataRequest {
                                   dataPreprocessor: any DataPreprocessor = StringResponseSerializer.defaultDataPreprocessor,
                                   encoding: String.Encoding? = nil,
                                   emptyResponseCodes: Set<Int> = StringResponseSerializer.defaultEmptyResponseCodes,
-                                  emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods) -> DataTask<String> {
+                                  emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods) -> sending DataTask<String> {
         serializingResponse(using: StringResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                             encoding: encoding,
                                                             emptyResponseCodes: emptyResponseCodes,
@@ -316,8 +316,7 @@ extension DataRequest {
     ///
     /// - Returns: The `DataTask`.
     public func serializingResponse<Serializer: ResponseSerializer>(using serializer: Serializer,
-                                                                    automaticallyCancelling shouldAutomaticallyCancel: Bool = true)
-        -> DataTask<Serializer.SerializedObject> {
+                                                                    automaticallyCancelling shouldAutomaticallyCancel: Bool = true) -> sending DataTask<Serializer.SerializedObject> {
         dataTask(automaticallyCancelling: shouldAutomaticallyCancel) { [self] in
             response(queue: underlyingQueue,
                      responseSerializer: serializer,
@@ -336,8 +335,7 @@ extension DataRequest {
     ///
     /// - Returns: The `DataTask`.
     public func serializingResponse<Serializer: DataResponseSerializerProtocol>(using serializer: Serializer,
-                                                                                automaticallyCancelling shouldAutomaticallyCancel: Bool = true)
-        -> DataTask<Serializer.SerializedObject> {
+                                                                                automaticallyCancelling shouldAutomaticallyCancel: Bool = true) -> sending DataTask<Serializer.SerializedObject> {
         dataTask(automaticallyCancelling: shouldAutomaticallyCancel) { [self] in
             response(queue: underlyingQueue,
                      responseSerializer: serializer,
@@ -346,7 +344,7 @@ extension DataRequest {
     }
 
     private func dataTask<Value>(automaticallyCancelling shouldAutomaticallyCancel: Bool,
-                                 forResponse onResponse: @Sendable @escaping (@escaping @Sendable (DataResponse<Value, AFError>) -> Void) -> Void)
+                                 forResponse onResponse:  @escaping (@escaping  (DataResponse<Value, AFError>) -> sending Void) -> Void)
         -> DataTask<Value> {
         let task = Task {
             await withTaskCancellationHandler {
@@ -438,7 +436,7 @@ extension DownloadRequest {
     public func serializingData(automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
                                 dataPreprocessor: any DataPreprocessor = DataResponseSerializer.defaultDataPreprocessor,
                                 emptyResponseCodes: Set<Int> = DataResponseSerializer.defaultEmptyResponseCodes,
-                                emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods) -> DownloadTask<Data> {
+                                emptyRequestMethods: Set<HTTPMethod> = DataResponseSerializer.defaultEmptyRequestMethods) -> sending DownloadTask<Data> {
         serializingDownload(using: DataResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                           emptyResponseCodes: emptyResponseCodes,
                                                           emptyRequestMethods: emptyRequestMethods),
@@ -482,7 +480,7 @@ extension DownloadRequest {
     ///                                properties. `true` by default.
     ///
     /// - Returns: The `DownloadTask`.
-    public func serializingDownloadedFileURL(automaticallyCancelling shouldAutomaticallyCancel: Bool = true) -> DownloadTask<URL> {
+    public func serializingDownloadedFileURL(automaticallyCancelling shouldAutomaticallyCancel: Bool = true) -> sending DownloadTask<URL> {
         serializingDownload(using: URLResponseSerializer(),
                             automaticallyCancelling: shouldAutomaticallyCancel)
     }
@@ -506,7 +504,7 @@ extension DownloadRequest {
                                   dataPreprocessor: any DataPreprocessor = StringResponseSerializer.defaultDataPreprocessor,
                                   encoding: String.Encoding? = nil,
                                   emptyResponseCodes: Set<Int> = StringResponseSerializer.defaultEmptyResponseCodes,
-                                  emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods) -> DownloadTask<String> {
+                                  emptyRequestMethods: Set<HTTPMethod> = StringResponseSerializer.defaultEmptyRequestMethods) -> sending DownloadTask<String> {
         serializingDownload(using: StringResponseSerializer(dataPreprocessor: dataPreprocessor,
                                                             encoding: encoding,
                                                             emptyResponseCodes: emptyResponseCodes,
@@ -524,8 +522,7 @@ extension DownloadRequest {
     ///
     /// - Returns: The `DownloadTask`.
     public func serializingDownload<Serializer: ResponseSerializer>(using serializer: Serializer,
-                                                                    automaticallyCancelling shouldAutomaticallyCancel: Bool = true)
-        -> DownloadTask<Serializer.SerializedObject> {
+                                                                    automaticallyCancelling shouldAutomaticallyCancel: Bool = true) -> sending DownloadTask<Serializer.SerializedObject> {
         downloadTask(automaticallyCancelling: shouldAutomaticallyCancel) { [self] in
             response(queue: underlyingQueue,
                      responseSerializer: serializer,
@@ -545,8 +542,7 @@ extension DownloadRequest {
     ///
     /// - Returns: The `DownloadTask`.
     public func serializingDownload<Serializer: DownloadResponseSerializerProtocol>(using serializer: Serializer,
-                                                                                    automaticallyCancelling shouldAutomaticallyCancel: Bool = true)
-        -> DownloadTask<Serializer.SerializedObject> {
+                                                                                    automaticallyCancelling shouldAutomaticallyCancel: Bool = true) -> sending DownloadTask<Serializer.SerializedObject> {
         downloadTask(automaticallyCancelling: shouldAutomaticallyCancel) { [self] in
             response(queue: underlyingQueue,
                      responseSerializer: serializer,
@@ -555,7 +551,7 @@ extension DownloadRequest {
     }
 
     private func downloadTask<Value>(automaticallyCancelling shouldAutomaticallyCancel: Bool,
-                                     forResponse onResponse: @Sendable @escaping (@escaping @Sendable (DownloadResponse<Value, AFError>) -> Void) -> Void)
+                                     forResponse onResponse:  @escaping (@escaping  (DownloadResponse<Value, AFError>) -> sending Void) -> Void)
         -> DownloadTask<Value> {
         let task = Task {
             await withTaskCancellationHandler {
@@ -594,7 +590,7 @@ public struct DataStreamTask: Sendable {
     ///   - bufferingPolicy: `         BufferingPolicy` that determines the stream's buffering behavior.`.unbounded` by default.
     ///
     /// - Returns:                   The `Stream`.
-    public func streamingData(automaticallyCancelling shouldAutomaticallyCancel: Bool = true, bufferingPolicy: Stream<Data, Never>.BufferingPolicy = .unbounded) -> Stream<Data, Never> {
+    public func streamingData(automaticallyCancelling shouldAutomaticallyCancel: Bool = true, bufferingPolicy: Stream<Data, Never>.BufferingPolicy = .unbounded) -> sending Stream<Data, Never> {
         createStream(automaticallyCancelling: shouldAutomaticallyCancel, bufferingPolicy: bufferingPolicy) { onStream in
             request.responseStream(on: .streamCompletionQueue(forRequestID: request.id), stream: onStream)
         }
@@ -607,7 +603,7 @@ public struct DataStreamTask: Sendable {
     ///                                which observation of the stream stops. `true` by default.
     ///   - bufferingPolicy: `         BufferingPolicy` that determines the stream's buffering behavior.`.unbounded` by default.
     /// - Returns:
-    public func streamingStrings(automaticallyCancelling shouldAutomaticallyCancel: Bool = true, bufferingPolicy: Stream<String, Never>.BufferingPolicy = .unbounded) -> Stream<String, Never> {
+    public func streamingStrings(automaticallyCancelling shouldAutomaticallyCancel: Bool = true, bufferingPolicy: Stream<String, Never>.BufferingPolicy = .unbounded) -> sending Stream<String, Never> {
         createStream(automaticallyCancelling: shouldAutomaticallyCancel, bufferingPolicy: bufferingPolicy) { onStream in
             request.responseStreamString(on: .streamCompletionQueue(forRequestID: request.id), stream: onStream)
         }
@@ -624,8 +620,7 @@ public struct DataStreamTask: Sendable {
     /// - Returns:            The `Stream`.
     public func streamingDecodables<T>(_ type: T.Type = T.self,
                                        automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
-                                       bufferingPolicy: Stream<T, AFError>.BufferingPolicy = .unbounded)
-        -> Stream<T, AFError> where T: Decodable & Sendable {
+                                       bufferingPolicy: Stream<T, AFError>.BufferingPolicy = .unbounded) -> sending Stream<T, AFError> where T: Decodable & Sendable {
         streamingResponses(serializedUsing: DecodableStreamSerializer<T>(),
                            automaticallyCancelling: shouldAutomaticallyCancel,
                            bufferingPolicy: bufferingPolicy)
@@ -642,8 +637,7 @@ public struct DataStreamTask: Sendable {
     /// - Returns:           The `Stream`.
     public func streamingResponses<Serializer: DataStreamSerializer>(serializedUsing serializer: Serializer,
                                                                      automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
-                                                                     bufferingPolicy: Stream<Serializer.SerializedObject, AFError>.BufferingPolicy = .unbounded)
-        -> Stream<Serializer.SerializedObject, AFError> {
+                                                                     bufferingPolicy: Stream<Serializer.SerializedObject, AFError>.BufferingPolicy = .unbounded) -> sending Stream<Serializer.SerializedObject, AFError> {
         createStream(automaticallyCancelling: shouldAutomaticallyCancel, bufferingPolicy: bufferingPolicy) { onStream in
             request.responseStream(using: serializer,
                                    on: .streamCompletionQueue(forRequestID: request.id),
@@ -653,7 +647,7 @@ public struct DataStreamTask: Sendable {
 
     private func createStream<Success, Failure: Error>(automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
                                                        bufferingPolicy: Stream<Success, Failure>.BufferingPolicy = .unbounded,
-                                                       forResponse onResponse: @Sendable @escaping (@escaping @Sendable (DataStreamRequest.Stream<Success, Failure>) -> Void) -> Void)
+                                                       forResponse onResponse:  @escaping (@escaping  (DataStreamRequest.Stream<Success, Failure>) -> sending Void) -> Void)
         -> Stream<Success, Failure> {
         StreamOf(bufferingPolicy: bufferingPolicy) {
             guard shouldAutomaticallyCancel,
@@ -693,7 +687,7 @@ extension DataStreamRequest {
     /// - Parameter bufferingPolicy: `BufferingPolicy` that determines the stream's buffering behavior.`.unbounded` by default.
     ///
     /// - Returns:                   The `StreamOf<HTTPURLResponse>`.
-    public func httpResponses(bufferingPolicy: StreamOf<HTTPURLResponse>.BufferingPolicy = .unbounded) -> StreamOf<HTTPURLResponse> {
+    public func httpResponses(bufferingPolicy: StreamOf<HTTPURLResponse>.BufferingPolicy = .unbounded) -> sending StreamOf<HTTPURLResponse> {
         stream(bufferingPolicy: bufferingPolicy) { [unowned self] continuation in
             onHTTPResponse(on: underlyingQueue) { response in
                 continuation.yield(response)
@@ -717,7 +711,7 @@ extension DataStreamRequest {
     /// - Returns:   The instance.
     @_disfavoredOverload
     @discardableResult
-    public func onHTTPResponse(perform handler: @escaping @Sendable (HTTPURLResponse) async -> ResponseDisposition) -> Self {
+    public func onHTTPResponse(perform handler: @escaping  (HTTPURLResponse) async -> sending ResponseDisposition) -> Self {
         onHTTPResponse(on: underlyingQueue) { response, completionHandler in
             Task {
                 let disposition = await handler(response)
@@ -740,7 +734,7 @@ extension DataStreamRequest {
     ///
     /// - Returns:   The instance.
     @discardableResult
-    public func onHTTPResponse(perform handler: @escaping @Sendable (HTTPURLResponse) async -> Void) -> Self {
+    public func onHTTPResponse(perform handler: @escaping  (HTTPURLResponse) async -> sending Void) -> Self {
         onHTTPResponse { response in
             await handler(response)
             return .allow
@@ -752,7 +746,7 @@ extension DataStreamRequest {
     /// Creates a `DataStreamTask` used to `await` streams of serialized values.
     ///
     /// - Returns: The `DataStreamTask`.
-    public func streamTask() -> DataStreamTask {
+    public func streamTask() -> sending DataStreamTask {
         DataStreamTask(request: self)
     }
 }
@@ -773,7 +767,7 @@ extension DataStreamRequest {
     public func streamingMessageEvents(
         automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
         bufferingPolicy: EventStreamOf<URLSessionWebSocketTask.Message, Never>.BufferingPolicy = .unbounded
-    ) -> EventStreamOf<URLSessionWebSocketTask.Message, Never> {
+    ) -> sending EventStreamOf<URLSessionWebSocketTask.Message, Never> {
         createStream(automaticallyCancelling: shouldAutomaticallyCancel,
                      bufferingPolicy: bufferingPolicy,
                      transform: { $0 }) { onEvent in
@@ -784,7 +778,7 @@ extension DataStreamRequest {
     public func streamingMessages(
         automaticallyCancelling shouldAutomaticallyCancel: Bool = true,
         bufferingPolicy: StreamOf<URLSessionWebSocketTask.Message>.BufferingPolicy = .unbounded
-    ) -> StreamOf<URLSessionWebSocketTask.Message> {
+    ) -> sending StreamOf<URLSessionWebSocketTask.Message> {
         createStream(automaticallyCancelling: shouldAutomaticallyCancel,
                      bufferingPolicy: bufferingPolicy,
                      transform: { $0.message }) { onEvent in
@@ -827,8 +821,8 @@ extension DataStreamRequest {
     private func createStream<Success, Value, Failure: Error>(
         automaticallyCancelling shouldAutomaticallyCancel: Bool,
         bufferingPolicy: StreamOf<Value>.BufferingPolicy,
-        transform: @escaping @Sendable (WebSocketRequest.Event<Success, Failure>) -> Value?,
-        forResponse onResponse: @Sendable @escaping (@escaping @Sendable (WebSocketRequest.Event<Success, Failure>) -> Void) -> Void
+        transform: @escaping  (WebSocketRequest.Event<Success, Failure>) -> sending Value?,
+        forResponse onResponse:  @escaping(@escaping  (WebSocketRequest.Event<Success, Failure>) -> sending Void) -> Void
     ) -> StreamOf<Value> {
         StreamOf(bufferingPolicy: bufferingPolicy) {
             guard shouldAutomaticallyCancel,
@@ -885,7 +879,7 @@ extension DataStreamRequest {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension WebSocketRequest {
-    public func webSocketTask() -> WebSocketTask {
+    public func webSocketTask() -> sending WebSocketTask {
         WebSocketTask(request: self)
     }
 }
@@ -895,7 +889,7 @@ extension DispatchQueue {
     fileprivate static let singleEventQueue = DispatchQueue(label: "org.alamofire.concurrencySingleEventQueue",
                                                             attributes: .concurrent)
 
-    fileprivate static func streamCompletionQueue(forRequestID id: UUID) -> DispatchQueue {
+    fileprivate static func streamCompletionQueue(forRequestID id: UUID) -> sending DispatchQueue {
         DispatchQueue(label: "org.alamofire.concurrencyStreamCompletionQueue-\(id)", target: .singleEventQueue)
     }
 }
@@ -908,18 +902,18 @@ public struct StreamOf<Element>: AsyncSequence {
     fileprivate typealias Continuation = AsyncStream<Element>.Continuation
 
     private let bufferingPolicy: BufferingPolicy
-    private let onTermination: (() -> Void)?
-    private let builder: (Continuation) -> Void
+    private let onTermination:(() -> sending Void)?
+    private let builder:(Continuation) -> sending Void
 
     fileprivate init(bufferingPolicy: BufferingPolicy = .unbounded,
-                     onTermination: (() -> Void)? = nil,
-                     builder: @escaping (Continuation) -> Void) {
+                     onTermination: (() -> sending Void)? = nil,
+                     builder: @escaping(Continuation) -> sending Void) {
         self.bufferingPolicy = bufferingPolicy
         self.onTermination = onTermination
         self.builder = builder
     }
 
-    public func makeAsyncIterator() -> Iterator {
+    public func makeAsyncIterator() -> sending Iterator {
         var continuation: AsyncStream<Element>.Continuation?
         let stream = AsyncStream<Element>(bufferingPolicy: bufferingPolicy) { innerContinuation in
             continuation = innerContinuation
@@ -934,9 +928,9 @@ public struct StreamOf<Element>: AsyncSequence {
 
     public struct Iterator: AsyncIteratorProtocol {
         private final class Token {
-            private let onDeinit: () -> Void
+            private let onDeinit:() -> sending Void
 
-            init(onDeinit: @escaping () -> Void) {
+            init(onDeinit: @escaping () -> sending Void) {
                 self.onDeinit = onDeinit
             }
 
@@ -948,12 +942,12 @@ public struct StreamOf<Element>: AsyncSequence {
         private var iterator: AsyncStream<Element>.AsyncIterator
         private let token: Token
 
-        init(iterator: AsyncStream<Element>.AsyncIterator, onCancellation: @escaping () -> Void) {
+        init(iterator: AsyncStream<Element>.AsyncIterator, onCancellation: @escaping () -> sending Void) {
             self.iterator = iterator
             token = Token(onDeinit: onCancellation)
         }
 
-        public mutating func next() async -> Element? {
+        public mutating func next() async -> sending Element? {
             await iterator.next()
         }
     }

--- a/Source/Features/EventMonitor.swift
+++ b/Source/Features/EventMonitor.swift
@@ -321,7 +321,7 @@ public final class CompositeEventMonitor: EventMonitor {
         self.monitors = Protected(monitors)
     }
 
-    func performEvent(_ event: @escaping @Sendable (any EventMonitor) -> Void) {
+    func performEvent(_ event: @escaping  (any EventMonitor) -> sending Void) {
         queue.async {
             self.monitors.read { monitors in
                 for monitor in monitors {
@@ -583,127 +583,127 @@ open class ClosureEventMonitor: EventMonitor, @unchecked Sendable {
     open var sessionDidBecomeInvalidWithError: ((URLSession, (any Error)?) -> Void)?
 
     /// Closure called on the `urlSession(_:task:didReceive:completionHandler:)`.
-    open var taskDidReceiveChallenge: ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> Void)?
+    open var taskDidReceiveChallenge:((URLSession, URLSessionTask, URLAuthenticationChallenge) -> sending Void)?
 
     /// Closure that receives `urlSession(_:task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:)` event.
-    open var taskDidSendBodyData: ((URLSession, URLSessionTask, Int64, Int64, Int64) -> Void)?
+    open var taskDidSendBodyData:((URLSession, URLSessionTask, Int64, Int64, Int64) -> sending Void)?
 
     /// Closure called on the `urlSession(_:task:needNewBodyStream:)` event.
-    open var taskNeedNewBodyStream: ((URLSession, URLSessionTask) -> Void)?
+    open var taskNeedNewBodyStream:((URLSession, URLSessionTask) -> sending Void)?
 
     /// Closure called on the `urlSession(_:task:willPerformHTTPRedirection:newRequest:completionHandler:)` event.
-    open var taskWillPerformHTTPRedirection: ((URLSession, URLSessionTask, HTTPURLResponse, URLRequest) -> Void)?
+    open var taskWillPerformHTTPRedirection:((URLSession, URLSessionTask, HTTPURLResponse, URLRequest) -> sending Void)?
 
     /// Closure called on the `urlSession(_:task:didFinishCollecting:)` event.
-    open var taskDidFinishCollectingMetrics: ((URLSession, URLSessionTask, URLSessionTaskMetrics) -> Void)?
+    open var taskDidFinishCollectingMetrics:((URLSession, URLSessionTask, URLSessionTaskMetrics) -> sending Void)?
 
     /// Closure called on the `urlSession(_:task:didCompleteWithError:)` event.
     open var taskDidComplete: ((URLSession, URLSessionTask, (any Error)?) -> Void)?
 
     /// Closure called on the `urlSession(_:taskIsWaitingForConnectivity:)` event.
-    open var taskIsWaitingForConnectivity: ((URLSession, URLSessionTask) -> Void)?
+    open var taskIsWaitingForConnectivity:((URLSession, URLSessionTask) -> sending Void)?
 
     /// Closure called on the `urlSession(_:dataTask:didReceive:completionHandler:)` event.
-    open var dataTaskDidReceiveResponse: ((URLSession, URLSessionDataTask, URLResponse) -> Void)?
+    open var dataTaskDidReceiveResponse:((URLSession, URLSessionDataTask, URLResponse) -> sending Void)?
 
     /// Closure that receives the `urlSession(_:dataTask:didReceive:)` event.
-    open var dataTaskDidReceiveData: ((URLSession, URLSessionDataTask, Data) -> Void)?
+    open var dataTaskDidReceiveData:((URLSession, URLSessionDataTask, Data) -> sending Void)?
 
     /// Closure called on the `urlSession(_:dataTask:willCacheResponse:completionHandler:)` event.
-    open var dataTaskWillCacheResponse: ((URLSession, URLSessionDataTask, CachedURLResponse) -> Void)?
+    open var dataTaskWillCacheResponse:((URLSession, URLSessionDataTask, CachedURLResponse) -> sending Void)?
 
     /// Closure called on the `urlSession(_:downloadTask:didFinishDownloadingTo:)` event.
-    open var downloadTaskDidFinishDownloadingToURL: ((URLSession, URLSessionDownloadTask, URL) -> Void)?
+    open var downloadTaskDidFinishDownloadingToURL:((URLSession, URLSessionDownloadTask, URL) -> sending Void)?
 
     /// Closure called on the `urlSession(_:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:)`
     /// event.
-    open var downloadTaskDidWriteData: ((URLSession, URLSessionDownloadTask, Int64, Int64, Int64) -> Void)?
+    open var downloadTaskDidWriteData:((URLSession, URLSessionDownloadTask, Int64, Int64, Int64) -> sending Void)?
 
     /// Closure called on the `urlSession(_:downloadTask:didResumeAtOffset:expectedTotalBytes:)` event.
-    open var downloadTaskDidResumeAtOffset: ((URLSession, URLSessionDownloadTask, Int64, Int64) -> Void)?
+    open var downloadTaskDidResumeAtOffset:((URLSession, URLSessionDownloadTask, Int64, Int64) -> sending Void)?
 
     // MARK: - Request Events
 
     /// Closure called on the `request(_:didCreateInitialURLRequest:)` event.
-    open var requestDidCreateInitialURLRequest: ((Request, URLRequest) -> Void)?
+    open var requestDidCreateInitialURLRequest:((Request, URLRequest) -> sending Void)?
 
     /// Closure called on the `request(_:didFailToCreateURLRequestWithError:)` event.
-    open var requestDidFailToCreateURLRequestWithError: ((Request, AFError) -> Void)?
+    open var requestDidFailToCreateURLRequestWithError:((Request, AFError) -> sending Void)?
 
     /// Closure called on the `request(_:didAdaptInitialRequest:to:)` event.
-    open var requestDidAdaptInitialRequestToAdaptedRequest: ((Request, URLRequest, URLRequest) -> Void)?
+    open var requestDidAdaptInitialRequestToAdaptedRequest:((Request, URLRequest, URLRequest) -> sending Void)?
 
     /// Closure called on the `request(_:didFailToAdaptURLRequest:withError:)` event.
-    open var requestDidFailToAdaptURLRequestWithError: ((Request, URLRequest, AFError) -> Void)?
+    open var requestDidFailToAdaptURLRequestWithError:((Request, URLRequest, AFError) -> sending Void)?
 
     /// Closure called on the `request(_:didCreateURLRequest:)` event.
-    open var requestDidCreateURLRequest: ((Request, URLRequest) -> Void)?
+    open var requestDidCreateURLRequest:((Request, URLRequest) -> sending Void)?
 
     /// Closure called on the `request(_:didCreateTask:)` event.
-    open var requestDidCreateTask: ((Request, URLSessionTask) -> Void)?
+    open var requestDidCreateTask:((Request, URLSessionTask) -> sending Void)?
 
     /// Closure called on the `request(_:didGatherMetrics:)` event.
-    open var requestDidGatherMetrics: ((Request, URLSessionTaskMetrics) -> Void)?
+    open var requestDidGatherMetrics:((Request, URLSessionTaskMetrics) -> sending Void)?
 
     /// Closure called on the `request(_:didFailTask:earlyWithError:)` event.
-    open var requestDidFailTaskEarlyWithError: ((Request, URLSessionTask, AFError) -> Void)?
+    open var requestDidFailTaskEarlyWithError:((Request, URLSessionTask, AFError) -> sending Void)?
 
     /// Closure called on the `request(_:didCompleteTask:with:)` event.
-    open var requestDidCompleteTaskWithError: ((Request, URLSessionTask, AFError?) -> Void)?
+    open var requestDidCompleteTaskWithError:((Request, URLSessionTask, AFError?) -> sending Void)?
 
     /// Closure called on the `requestIsRetrying(_:)` event.
-    open var requestIsRetrying: ((Request) -> Void)?
+    open var requestIsRetrying:((Request) -> sending Void)?
 
     /// Closure called on the `requestDidFinish(_:)` event.
-    open var requestDidFinish: ((Request) -> Void)?
+    open var requestDidFinish:((Request) -> sending Void)?
 
     /// Closure called on the `requestDidResume(_:)` event.
-    open var requestDidResume: ((Request) -> Void)?
+    open var requestDidResume:((Request) -> sending Void)?
 
     /// Closure called on the `request(_:didResumeTask:)` event.
-    open var requestDidResumeTask: ((Request, URLSessionTask) -> Void)?
+    open var requestDidResumeTask:((Request, URLSessionTask) -> sending Void)?
 
     /// Closure called on the `requestDidSuspend(_:)` event.
-    open var requestDidSuspend: ((Request) -> Void)?
+    open var requestDidSuspend:((Request) -> sending Void)?
 
     /// Closure called on the `request(_:didSuspendTask:)` event.
-    open var requestDidSuspendTask: ((Request, URLSessionTask) -> Void)?
+    open var requestDidSuspendTask:((Request, URLSessionTask) -> sending Void)?
 
     /// Closure called on the `requestDidCancel(_:)` event.
-    open var requestDidCancel: ((Request) -> Void)?
+    open var requestDidCancel:((Request) -> sending Void)?
 
     /// Closure called on the `request(_:didCancelTask:)` event.
-    open var requestDidCancelTask: ((Request, URLSessionTask) -> Void)?
+    open var requestDidCancelTask:((Request, URLSessionTask) -> sending Void)?
 
     /// Closure called on the `request(_:didValidateRequest:response:data:withResult:)` event.
-    open var requestDidValidateRequestResponseDataWithResult: ((DataRequest, URLRequest?, HTTPURLResponse, Data?, Request.ValidationResult) -> Void)?
+    open var requestDidValidateRequestResponseDataWithResult:((DataRequest, URLRequest?, HTTPURLResponse, Data?, Request.ValidationResult) -> sending Void)?
 
     /// Closure called on the `request(_:didParseResponse:)` event.
-    open var requestDidParseResponse: ((DataRequest, DataResponse<Data?, AFError>) -> Void)?
+    open var requestDidParseResponse:((DataRequest, DataResponse<Data?, AFError>) -> sending Void)?
 
     /// Closure called on the `request(_:didValidateRequest:response:withResult:)` event.
-    open var requestDidValidateRequestResponseWithResult: ((DataStreamRequest, URLRequest?, HTTPURLResponse, Request.ValidationResult) -> Void)?
+    open var requestDidValidateRequestResponseWithResult:((DataStreamRequest, URLRequest?, HTTPURLResponse, Request.ValidationResult) -> sending Void)?
 
     /// Closure called on the `request(_:didCreateUploadable:)` event.
-    open var requestDidCreateUploadable: ((UploadRequest, UploadRequest.Uploadable) -> Void)?
+    open var requestDidCreateUploadable:((UploadRequest, UploadRequest.Uploadable) -> sending Void)?
 
     /// Closure called on the `request(_:didFailToCreateUploadableWithError:)` event.
-    open var requestDidFailToCreateUploadableWithError: ((UploadRequest, AFError) -> Void)?
+    open var requestDidFailToCreateUploadableWithError:((UploadRequest, AFError) -> sending Void)?
 
     /// Closure called on the `request(_:didProvideInputStream:)` event.
-    open var requestDidProvideInputStream: ((UploadRequest, InputStream) -> Void)?
+    open var requestDidProvideInputStream:((UploadRequest, InputStream) -> sending Void)?
 
     /// Closure called on the `request(_:didFinishDownloadingUsing:with:)` event.
-    open var requestDidFinishDownloadingUsingTaskWithResult: ((DownloadRequest, URLSessionTask, Result<URL, AFError>) -> Void)?
+    open var requestDidFinishDownloadingUsingTaskWithResult:((DownloadRequest, URLSessionTask, Result<URL, AFError>) -> sending Void)?
 
     /// Closure called on the `request(_:didCreateDestinationURL:)` event.
-    open var requestDidCreateDestinationURL: ((DownloadRequest, URL) -> Void)?
+    open var requestDidCreateDestinationURL:((DownloadRequest, URL) -> sending Void)?
 
     /// Closure called on the `request(_:didValidateRequest:response:temporaryURL:destinationURL:withResult:)` event.
-    open var requestDidValidateRequestResponseFileURLWithResult: ((DownloadRequest, URLRequest?, HTTPURLResponse, URL?, Request.ValidationResult) -> Void)?
+    open var requestDidValidateRequestResponseFileURLWithResult:((DownloadRequest, URLRequest?, HTTPURLResponse, URL?, Request.ValidationResult) -> sending Void)?
 
     /// Closure called on the `request(_:didParseResponse:)` event.
-    open var requestDidParseDownloadResponse: ((DownloadRequest, DownloadResponse<URL?, AFError>) -> Void)?
+    open var requestDidParseDownloadResponse:((DownloadRequest, DownloadResponse<URL?, AFError>) -> sending Void)?
 
     public let queue: DispatchQueue
 

--- a/Source/Features/NetworkReachabilityManager.swift
+++ b/Source/Features/NetworkReachabilityManager.swift
@@ -64,7 +64,7 @@ open class NetworkReachabilityManager: @unchecked Sendable {
 
     /// A closure executed when the network reachability status changes. The closure takes a single argument: the
     /// network reachability status.
-    public typealias Listener = @Sendable (NetworkReachabilityStatus) -> Void
+    public typealias Listener = (NetworkReachabilityStatus) -> sending Void
 
     /// Default `NetworkReachabilityManager` for the zero address and a `listenerQueue` of `.main`.
     public static let `default` = NetworkReachabilityManager()
@@ -165,7 +165,7 @@ open class NetworkReachabilityManager: @unchecked Sendable {
     @preconcurrency
     @discardableResult
     open func startListening(onQueue queue: DispatchQueue = .main,
-                             onUpdatePerforming listener: @escaping Listener) -> Bool {
+                             onUpdatePerforming listener: @escaping Listener) -> sending Bool {
         stopListening()
 
         mutableState.write { state in

--- a/Source/Features/RedirectHandler.swift
+++ b/Source/Features/RedirectHandler.swift
@@ -42,7 +42,7 @@ public protocol RedirectHandler: Sendable {
     func task(_ task: URLSessionTask,
               willBeRedirectedTo request: URLRequest,
               for response: HTTPURLResponse,
-              completion: @escaping (URLRequest?) -> Void)
+              completion: @escaping (URLRequest?) -> sending Void)
 }
 
 // MARK: -
@@ -56,7 +56,7 @@ public struct Redirector {
         /// Do not follow the redirect defined in the response.
         case doNotFollow
         /// Modify the redirect request defined in the response.
-        case modify(@Sendable (_ task: URLSessionTask, _ request: URLRequest, _ response: HTTPURLResponse) -> URLRequest?)
+        case modify( (_ task: URLSessionTask, _ request: URLRequest, _ response: HTTPURLResponse) -> sending URLRequest?)
     }
 
     /// Returns a `Redirector` with a `.follow` `Behavior`.
@@ -81,7 +81,7 @@ extension Redirector: RedirectHandler {
     public func task(_ task: URLSessionTask,
                      willBeRedirectedTo request: URLRequest,
                      for response: HTTPURLResponse,
-                     completion: @escaping (URLRequest?) -> Void) {
+                     completion: @escaping (URLRequest?) -> sending Void) {
         switch behavior {
         case .follow:
             completion(request)
@@ -105,7 +105,7 @@ extension RedirectHandler where Self == Redirector {
     ///
     /// - Parameter closure: Closure used to modify the redirect.
     /// - Returns:           The `Redirector`.
-    public static func modify(using closure: @escaping @Sendable (URLSessionTask, URLRequest, HTTPURLResponse) -> URLRequest?) -> Redirector {
+    public static func modify(using closure: @escaping  (URLSessionTask, URLRequest, HTTPURLResponse) -> sending URLRequest?) -> Redirector {
         Redirector(behavior: .modify(closure))
     }
 }

--- a/Source/Features/RequestCompression.swift
+++ b/Source/Features/RequestCompression.swift
@@ -54,7 +54,7 @@ public struct DeflateRequestCompressor: Sendable, RequestInterceptor {
     /// Behavior to use when the outgoing `URLRequest` already has a `Content-Encoding` header.
     public let duplicateHeaderBehavior: DuplicateHeaderBehavior
     /// Closure which determines whether the outgoing body data should be compressed.
-    public let shouldCompressBodyData: @Sendable (_ bodyData: Data) -> Bool
+    public let shouldCompressBodyData: (_ bodyData: Data) -> sending Bool
 
     /// Creates an instance with the provided parameters.
     ///
@@ -62,12 +62,12 @@ public struct DeflateRequestCompressor: Sendable, RequestInterceptor {
     ///   - duplicateHeaderBehavior: `DuplicateHeaderBehavior` to use. `.error` by default.
     ///   - shouldCompressBodyData:  Closure which determines whether the outgoing body data should be compressed. `true` by default.
     public init(duplicateHeaderBehavior: DuplicateHeaderBehavior = .error,
-                shouldCompressBodyData: @escaping @Sendable (_ bodyData: Data) -> Bool = { _ in true }) {
+                shouldCompressBodyData: @escaping  (_ bodyData: Data) -> sending Bool = { _ in true }) {
         self.duplicateHeaderBehavior = duplicateHeaderBehavior
         self.shouldCompressBodyData = shouldCompressBodyData
     }
 
-    public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, any Error>) -> Void) {
+    public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, any Error>) -> sending Void) {
         // No need to compress unless we have body data. No support for compressing streams.
         guard let bodyData = urlRequest.httpBody else {
             completion(.success(urlRequest))
@@ -104,7 +104,7 @@ public struct DeflateRequestCompressor: Sendable, RequestInterceptor {
         }
     }
 
-    func deflate(_ data: Data) throws -> Data {
+    func deflate(_ data: Data) throws -> sending Data {
         var output = Data([0x78, 0x5E]) // Header
         try output.append((data as NSData).compressed(using: .zlib) as Data)
         var checksum = adler32Checksum(of: data).bigEndian
@@ -113,7 +113,7 @@ public struct DeflateRequestCompressor: Sendable, RequestInterceptor {
         return output
     }
 
-    func adler32Checksum(of data: Data) -> UInt32 {
+    func adler32Checksum(of data: Data) -> sending UInt32 {
         data.withUnsafeBytes { buffer in
             UInt32(adler32(1, buffer.baseAddress, UInt32(buffer.count)))
         }
@@ -137,7 +137,7 @@ extension RequestInterceptor where Self == DeflateRequestCompressor {
     /// - Returns: The `DeflateRequestCompressor`.
     public static func deflateCompressor(
         duplicateHeaderBehavior: DeflateRequestCompressor.DuplicateHeaderBehavior = .error,
-        shouldCompressBodyData: @escaping @Sendable (_ bodyData: Data) -> Bool = { _ in true }
+        shouldCompressBodyData: @escaping  (_ bodyData: Data) -> sending Bool = { _ in true }
     ) -> DeflateRequestCompressor {
         DeflateRequestCompressor(duplicateHeaderBehavior: duplicateHeaderBehavior,
                                  shouldCompressBodyData: shouldCompressBodyData)

--- a/Source/Features/RequestInterceptor.swift
+++ b/Source/Features/RequestInterceptor.swift
@@ -43,7 +43,7 @@ public protocol RequestAdapter: Sendable {
     ///   - urlRequest: The `URLRequest` to adapt.
     ///   - session:    The `Session` that will execute the `URLRequest`.
     ///   - completion: The completion handler that must be called when adaptation is complete.
-    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping @Sendable (_ result: Result<URLRequest, any Error>) -> Void)
+    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping  (_ result: Result<URLRequest, any Error>) -> sending Void)
 
     /// Inspects and adapts the specified `URLRequest` in some manner and calls the completion handler with the Result.
     ///
@@ -51,12 +51,12 @@ public protocol RequestAdapter: Sendable {
     ///   - urlRequest: The `URLRequest` to adapt.
     ///   - state:      The `RequestAdapterState` associated with the `URLRequest`.
     ///   - completion: The completion handler that must be called when adaptation is complete.
-    func adapt(_ urlRequest: URLRequest, using state: RequestAdapterState, completion: @escaping @Sendable (_ result: Result<URLRequest, any Error>) -> Void)
+    func adapt(_ urlRequest: URLRequest, using state: RequestAdapterState, completion: @escaping  (_ result: Result<URLRequest, any Error>) -> sending Void)
 }
 
 extension RequestAdapter {
     @preconcurrency
-    public func adapt(_ urlRequest: URLRequest, using state: RequestAdapterState, completion: @escaping @Sendable (_ result: Result<URLRequest, any Error>) -> Void) {
+    public func adapt(_ urlRequest: URLRequest, using state: RequestAdapterState, completion: @escaping  (_ result: Result<URLRequest, any Error>) -> sending Void) {
         adapt(urlRequest, for: state.session, completion: completion)
     }
 }
@@ -110,7 +110,7 @@ public protocol RequestRetrier: Sendable {
     ///   - session:    `Session` that produced the `Request`.
     ///   - error:      `Error` encountered while executing the `Request`.
     ///   - completion: Completion closure to be executed when a retry decision has been determined.
-    func retry(_ request: Request, for session: Session, dueTo error: any Error, completion: @escaping @Sendable (RetryResult) -> Void)
+    func retry(_ request: Request, for session: Session, dueTo error: any Error, completion: @escaping  (RetryResult) -> sending Void)
 }
 
 // MARK: -
@@ -120,7 +120,7 @@ public protocol RequestInterceptor: RequestAdapter, RequestRetrier {}
 
 extension RequestInterceptor {
     @preconcurrency
-    public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
+    public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping  (Result<URLRequest, any Error>) -> sending Void) {
         completion(.success(urlRequest))
     }
 
@@ -128,21 +128,21 @@ extension RequestInterceptor {
     public func retry(_ request: Request,
                       for session: Session,
                       dueTo error: any Error,
-                      completion: @escaping @Sendable (RetryResult) -> Void) {
+                      completion: @escaping  (RetryResult) -> sending Void) {
         completion(.doNotRetry)
     }
 }
 
 /// `RequestAdapter` closure definition.
-public typealias AdaptHandler = @Sendable (_ request: URLRequest,
+public typealias AdaptHandler = (_ request: URLRequest,
                                            _ session: Session,
-                                           _ completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) -> Void
+                                           _ completion: @escaping  (Result<URLRequest, any Error>) -> sending Void) -> Void
 
 /// `RequestRetrier` closure definition.
-public typealias RetryHandler = @Sendable (_ request: Request,
+public typealias RetryHandler = (_ request: Request,
                                            _ session: Session,
                                            _ error: any Error,
-                                           _ completion: @escaping @Sendable (RetryResult) -> Void) -> Void
+                                           _ completion: @escaping  (RetryResult) -> sending Void) -> Void
 
 // MARK: -
 
@@ -160,12 +160,12 @@ open class Adapter: @unchecked Sendable, RequestInterceptor {
     }
 
     @preconcurrency
-    open func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
+    open func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping  (Result<URLRequest, any Error>) -> sending Void) {
         adaptHandler(urlRequest, session, completion)
     }
 
     @preconcurrency
-    open func adapt(_ urlRequest: URLRequest, using state: RequestAdapterState, completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
+    open func adapt(_ urlRequest: URLRequest, using state: RequestAdapterState, completion: @escaping  (Result<URLRequest, any Error>) -> sending Void) {
         adaptHandler(urlRequest, state.session, completion)
     }
 }
@@ -176,7 +176,7 @@ extension RequestAdapter where Self == Adapter {
     /// - Parameter closure: `AdaptHandler` to use to adapt the request.
     /// - Returns:           The `Adapter`.
     @preconcurrency
-    public static func adapter(using closure: @escaping AdaptHandler) -> Adapter {
+    public static func adapter(using closure: @escaping AdaptHandler) -> sending Adapter {
         Adapter(closure)
     }
 }
@@ -199,7 +199,7 @@ open class Retrier: @unchecked Sendable, RequestInterceptor {
     open func retry(_ request: Request,
                     for session: Session,
                     dueTo error: any Error,
-                    completion: @escaping @Sendable (RetryResult) -> Void) {
+                    completion: @escaping  (RetryResult) -> sending Void) {
         retryHandler(request, session, error, completion)
     }
 }
@@ -210,7 +210,7 @@ extension RequestRetrier where Self == Retrier {
     /// - Parameter closure: `RetryHandler` to use to retry the request.
     /// - Returns:           The `Retrier`.
     @preconcurrency
-    public static func retrier(using closure: @escaping RetryHandler) -> Retrier {
+    public static func retrier(using closure: @escaping RetryHandler) -> sending Retrier {
         Retrier(closure)
     }
 }
@@ -258,14 +258,14 @@ open class Interceptor: @unchecked Sendable, RequestInterceptor {
     }
 
     @preconcurrency
-    open func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
+    open func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping  (Result<URLRequest, any Error>) -> sending Void) {
         adapt(urlRequest, for: session, using: adapters, completion: completion)
     }
 
     private func adapt(_ urlRequest: URLRequest,
                        for session: Session,
                        using adapters: [any RequestAdapter],
-                       completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
+                       completion: @escaping  (Result<URLRequest, any Error>) -> sending Void) {
         var pendingAdapters = adapters
 
         guard !pendingAdapters.isEmpty else { completion(.success(urlRequest)); return }
@@ -283,14 +283,14 @@ open class Interceptor: @unchecked Sendable, RequestInterceptor {
     }
 
     @preconcurrency
-    open func adapt(_ urlRequest: URLRequest, using state: RequestAdapterState, completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
+    open func adapt(_ urlRequest: URLRequest, using state: RequestAdapterState, completion: @escaping  (Result<URLRequest, any Error>) -> sending Void) {
         adapt(urlRequest, using: state, adapters: adapters, completion: completion)
     }
 
     private func adapt(_ urlRequest: URLRequest,
                        using state: RequestAdapterState,
                        adapters: [any RequestAdapter],
-                       completion: @escaping @Sendable (Result<URLRequest, any Error>) -> Void) {
+                       completion: @escaping  (Result<URLRequest, any Error>) -> sending Void) {
         var pendingAdapters = adapters
 
         guard !pendingAdapters.isEmpty else { completion(.success(urlRequest)); return }
@@ -311,7 +311,7 @@ open class Interceptor: @unchecked Sendable, RequestInterceptor {
     open func retry(_ request: Request,
                     for session: Session,
                     dueTo error: any Error,
-                    completion: @escaping @Sendable (RetryResult) -> Void) {
+                    completion: @escaping  (RetryResult) -> sending Void) {
         retry(request, for: session, dueTo: error, using: retriers, completion: completion)
     }
 
@@ -319,7 +319,7 @@ open class Interceptor: @unchecked Sendable, RequestInterceptor {
                        for session: Session,
                        dueTo error: any Error,
                        using retriers: [any RequestRetrier],
-                       completion: @escaping @Sendable (RetryResult) -> Void) {
+                       completion: @escaping  (RetryResult) -> sending Void) {
         var pendingRetriers = retriers
 
         guard !pendingRetriers.isEmpty else { completion(.doNotRetry); return }
@@ -346,7 +346,7 @@ extension RequestInterceptor where Self == Interceptor {
     ///   - retrier: `RetryHandler` to use to retry the request.
     /// - Returns:   The `Interceptor`.
     @preconcurrency
-    public static func interceptor(adapter: @escaping AdaptHandler, retrier: @escaping RetryHandler) -> Interceptor {
+    public static func interceptor(adapter: @escaping AdaptHandler, retrier: @escaping RetryHandler) -> sending Interceptor {
         Interceptor(adaptHandler: adapter, retryHandler: retrier)
     }
 
@@ -356,7 +356,7 @@ extension RequestInterceptor where Self == Interceptor {
     ///   - retrier: `RequestRetrier` to use to retry the request.
     /// - Returns:   The `Interceptor`.
     @preconcurrency
-    public static func interceptor(adapter: any RequestAdapter, retrier: any RequestRetrier) -> Interceptor {
+    public static func interceptor(adapter: any RequestAdapter, retrier: any RequestRetrier) -> sending Interceptor {
         Interceptor(adapter: adapter, retrier: retrier)
     }
 
@@ -370,7 +370,7 @@ extension RequestInterceptor where Self == Interceptor {
     @preconcurrency
     public static func interceptor(adapters: [any RequestAdapter] = [],
                                    retriers: [any RequestRetrier] = [],
-                                   interceptors: [any RequestInterceptor] = []) -> Interceptor {
+                                   interceptors: [any RequestInterceptor] = []) -> sending Interceptor {
         Interceptor(adapters: adapters, retriers: retriers, interceptors: interceptors)
     }
 }

--- a/Source/Features/URLEncodedFormEncoder.swift
+++ b/Source/Features/URLEncodedFormEncoder.swift
@@ -61,7 +61,7 @@ public final class URLEncodedFormEncoder {
         /// Brackets containing the item index are appended. This matches the jQuery and Node.js behavior.
         case indexInBrackets
         /// Provide a custom array key encoding with the given closure.
-        case custom((_ key: String, _ index: Int) -> String)
+        case custom((_ key: String, _ index: Int) -> sending String)
 
         /// Encodes the key according to the encoding.
         ///
@@ -70,7 +70,7 @@ public final class URLEncodedFormEncoder {
         ///     - index: When this enum instance is `.indexInBrackets`, the `index` to encode.
         ///
         /// - Returns:   The encoded key.
-        func encode(_ key: String, atIndex index: Int) -> String {
+        func encode(_ key: String, atIndex index: Int) -> sending String {
             switch self {
             case .brackets: "\(key)[]"
             case .noBrackets: key
@@ -92,7 +92,7 @@ public final class URLEncodedFormEncoder {
         /// - Parameter value: The `Bool` to encode.
         ///
         /// - Returns:         The encoded `String`.
-        func encode(_ value: Bool) -> String {
+        func encode(_ value: Bool) -> sending String {
             switch self {
             case .numeric: value ? "1" : "0"
             case .literal: value ? "true" : "false"
@@ -107,7 +107,7 @@ public final class URLEncodedFormEncoder {
         /// Encodes `Data` as a Base64-encoded string. This is the default encoding.
         case base64
         /// Encode the `Data` as a custom value encoded by the given closure.
-        case custom((Data) throws -> String)
+        case custom((Data) throws -> sending String)
 
         /// Encodes `Data` according to the encoding.
         ///
@@ -115,7 +115,7 @@ public final class URLEncodedFormEncoder {
         ///
         /// - Returns:        The encoded `String`, or `nil` if the `Data` should be encoded according to its
         ///                   `Encodable` implementation.
-        func encode(_ data: Data) throws -> String? {
+        func encode(_ data: Data) throws -> sending String? {
             switch self {
             case .deferredToData: nil
             case .base64: data.base64EncodedString()
@@ -144,7 +144,7 @@ public final class URLEncodedFormEncoder {
         /// Encodes `Date`s using the given `DateFormatter`.
         case formatted(DateFormatter)
         /// Encodes `Date`s using the given closure.
-        case custom((Date) throws -> String)
+        case custom((Date) throws -> sending String)
 
         /// Encodes the date according to the encoding.
         ///
@@ -152,7 +152,7 @@ public final class URLEncodedFormEncoder {
         ///
         /// - Returns:        The encoded `String`, or `nil` if the `Date` should be encoded according to its
         ///                   `Encodable` implementation.
-        func encode(_ date: Date) throws -> String? {
+        func encode(_ date: Date) throws -> sending String? {
             switch self {
             case .deferredToDate:
                 nil
@@ -209,9 +209,9 @@ public final class URLEncodedFormEncoder {
         /// For example `oneTwoThree` becomes  `onetwothree`.
         case lowercased
         /// A custom encoding using the provided closure.
-        case custom((String) -> String)
+        case custom((String) -> sending String)
 
-        func encode(_ key: String) -> String {
+        func encode(_ key: String) -> sending String {
             switch self {
             case .useDefaultKeys: key
             case .convertToSnakeCase: convertToSnakeCase(key)
@@ -223,15 +223,15 @@ public final class URLEncodedFormEncoder {
             }
         }
 
-        private func convertToSnakeCase(_ key: String) -> String {
+        private func convertToSnakeCase(_ key: String) -> sending String {
             convert(key, usingSeparator: "_")
         }
 
-        private func convertToKebabCase(_ key: String) -> String {
+        private func convertToKebabCase(_ key: String) -> sending String {
             convert(key, usingSeparator: "-")
         }
 
-        private func convert(_ key: String, usingSeparator separator: String) -> String {
+        private func convert(_ key: String, usingSeparator separator: String) -> sending String {
             guard !key.isEmpty else { return key }
 
             var words: [Range<String.Index>] = []
@@ -301,16 +301,16 @@ public final class URLEncodedFormEncoder {
         /// Encodes key paths by separating each component with dots. e.g. `parent.child.grandchild`.
         public static let dots = KeyPathEncoding { ".\($0)" }
 
-        private let encoding: @Sendable (_ subkey: String) -> String
+        private let encoding: (_ subkey: String) -> sending String
 
         /// Creates an instance with the encoding closure called for each sub-key in a key path.
         ///
         /// - Parameter encoding: Closure used to perform the encoding.
-        public init(encoding: @escaping @Sendable (_ subkey: String) -> String) {
+        public init(encoding: @escaping  (_ subkey: String) -> sending String) {
             self.encoding = encoding
         }
 
-        func encodeKeyPath(_ keyPath: String) -> String {
+        func encodeKeyPath(_ keyPath: String) -> sending String {
             encoding(keyPath)
         }
     }
@@ -324,16 +324,16 @@ public final class URLEncodedFormEncoder {
         /// Encodes `nil` as `null`.
         public static let null = NilEncoding { "null" }
 
-        private let encoding: @Sendable () -> String?
+        private let encoding: () -> sending String?
 
         /// Creates an instance with the encoding closure called for `nil` values.
         ///
         /// - Parameter encoding: Closure used to perform the encoding.
-        public init(encoding: @escaping @Sendable () -> String?) {
+        public init(encoding: @escaping  () -> sending String?) {
             self.encoding = encoding
         }
 
-        func encodeNil() -> String? {
+        func encodeNil() -> sending String? {
             encoding()
         }
     }
@@ -350,7 +350,7 @@ public final class URLEncodedFormEncoder {
         /// - Parameter string: The `String` to encode.
         ///
         /// - Returns:          The encoded `String`.
-        func encode(_ string: String) -> String {
+        func encode(_ string: String) -> sending String {
             switch self {
             case .percentEscaped: string.replacingOccurrences(of: " ", with: "%20")
             case .plusReplaced: string.replacingOccurrences(of: " ", with: "+")
@@ -431,7 +431,7 @@ public final class URLEncodedFormEncoder {
         self.allowedCharacters = allowedCharacters
     }
 
-    func encode(_ value: any Encodable) throws -> URLEncodedFormComponent {
+    func encode(_ value: any Encodable) throws -> sending URLEncodedFormComponent {
         let context = URLEncodedFormContext(.object([]))
         let encoder = _URLEncodedFormEncoder(context: context,
                                              boolEncoding: boolEncoding,
@@ -449,7 +449,7 @@ public final class URLEncodedFormEncoder {
     ///
     /// - Returns:         The encoded `String`.
     /// - Throws:          An `Error` or `EncodingError` instance if encoding fails.
-    public func encode(_ value: any Encodable) throws -> String {
+    public func encode(_ value: any Encodable) throws -> sending String {
         let component: URLEncodedFormComponent = try encode(value)
 
         guard case let .object(object) = component else {
@@ -475,7 +475,7 @@ public final class URLEncodedFormEncoder {
     /// - Returns:         The encoded `Data`.
     ///
     /// - Throws:          An `Error` or `EncodingError` instance if encoding fails.
-    public func encode(_ value: any Encodable) throws -> Data {
+    public func encode(_ value: any Encodable) throws -> sending Data {
         let string: String = try encode(value)
 
         return Data(string.utf8)
@@ -510,7 +510,7 @@ final class _URLEncodedFormEncoder {
 }
 
 extension _URLEncodedFormEncoder: Encoder {
-    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
+    func container<Key>(keyedBy type: Key.Type) -> sending KeyedEncodingContainer<Key> where Key: CodingKey {
         let container = _URLEncodedFormEncoder.KeyedContainer<Key>(context: context,
                                                                    codingPath: codingPath,
                                                                    boolEncoding: boolEncoding,
@@ -520,7 +520,7 @@ extension _URLEncodedFormEncoder: Encoder {
         return KeyedEncodingContainer(container)
     }
 
-    func unkeyedContainer() -> any UnkeyedEncodingContainer {
+    func unkeyedContainer() -> sending any UnkeyedEncodingContainer {
         _URLEncodedFormEncoder.UnkeyedContainer(context: context,
                                                 codingPath: codingPath,
                                                 boolEncoding: boolEncoding,
@@ -529,7 +529,7 @@ extension _URLEncodedFormEncoder: Encoder {
                                                 nilEncoding: nilEncoding)
     }
 
-    func singleValueContainer() -> any SingleValueEncodingContainer {
+    func singleValueContainer() -> sending any SingleValueEncodingContainer {
         _URLEncodedFormEncoder.SingleValueContainer(context: context,
                                                     codingPath: codingPath,
                                                     boolEncoding: boolEncoding,
@@ -682,7 +682,7 @@ extension _URLEncodedFormEncoder {
             self.nilEncoding = nilEncoding
         }
 
-        private func nestedCodingPath(for key: any CodingKey) -> [any CodingKey] {
+        private func nestedCodingPath(for key: any CodingKey) -> sending [any CodingKey] {
             codingPath + [key]
         }
     }
@@ -768,7 +768,7 @@ extension _URLEncodedFormEncoder.KeyedContainer: KeyedEncodingContainerProtocol 
         try container.encode(value)
     }
 
-    func nestedSingleValueEncoder(for key: Key) -> any SingleValueEncodingContainer {
+    func nestedSingleValueEncoder(for key: Key) -> sending any SingleValueEncodingContainer {
         let container = _URLEncodedFormEncoder.SingleValueContainer(context: context,
                                                                     codingPath: nestedCodingPath(for: key),
                                                                     boolEncoding: boolEncoding,
@@ -779,7 +779,7 @@ extension _URLEncodedFormEncoder.KeyedContainer: KeyedEncodingContainerProtocol 
         return container
     }
 
-    func nestedUnkeyedContainer(forKey key: Key) -> any UnkeyedEncodingContainer {
+    func nestedUnkeyedContainer(forKey key: Key) -> sending any UnkeyedEncodingContainer {
         let container = _URLEncodedFormEncoder.UnkeyedContainer(context: context,
                                                                 codingPath: nestedCodingPath(for: key),
                                                                 boolEncoding: boolEncoding,
@@ -790,7 +790,7 @@ extension _URLEncodedFormEncoder.KeyedContainer: KeyedEncodingContainerProtocol 
         return container
     }
 
-    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> sending KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
         let container = _URLEncodedFormEncoder.KeyedContainer<NestedKey>(context: context,
                                                                          codingPath: nestedCodingPath(for: key),
                                                                          boolEncoding: boolEncoding,
@@ -801,7 +801,7 @@ extension _URLEncodedFormEncoder.KeyedContainer: KeyedEncodingContainerProtocol 
         return KeyedEncodingContainer(container)
     }
 
-    func superEncoder() -> any Encoder {
+    func superEncoder() -> sending any Encoder {
         _URLEncodedFormEncoder(context: context,
                                codingPath: codingPath,
                                boolEncoding: boolEncoding,
@@ -810,7 +810,7 @@ extension _URLEncodedFormEncoder.KeyedContainer: KeyedEncodingContainerProtocol 
                                nilEncoding: nilEncoding)
     }
 
-    func superEncoder(forKey key: Key) -> any Encoder {
+    func superEncoder(forKey key: Key) -> sending any Encoder {
         _URLEncodedFormEncoder(context: context,
                                codingPath: nestedCodingPath(for: key),
                                boolEncoding: boolEncoding,
@@ -1007,7 +1007,7 @@ extension _URLEncodedFormEncoder.UnkeyedContainer: UnkeyedEncodingContainer {
         try container.encode(value)
     }
 
-    func nestedSingleValueContainer() -> any SingleValueEncodingContainer {
+    func nestedSingleValueContainer() -> sending any SingleValueEncodingContainer {
         defer { count += 1 }
 
         return _URLEncodedFormEncoder.SingleValueContainer(context: context,
@@ -1018,7 +1018,7 @@ extension _URLEncodedFormEncoder.UnkeyedContainer: UnkeyedEncodingContainer {
                                                            nilEncoding: nilEncoding)
     }
 
-    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> sending KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
         defer { count += 1 }
         let container = _URLEncodedFormEncoder.KeyedContainer<NestedKey>(context: context,
                                                                          codingPath: nestedCodingPath,
@@ -1030,7 +1030,7 @@ extension _URLEncodedFormEncoder.UnkeyedContainer: UnkeyedEncodingContainer {
         return KeyedEncodingContainer(container)
     }
 
-    func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+    func nestedUnkeyedContainer() -> sending any UnkeyedEncodingContainer {
         defer { count += 1 }
 
         return _URLEncodedFormEncoder.UnkeyedContainer(context: context,
@@ -1041,7 +1041,7 @@ extension _URLEncodedFormEncoder.UnkeyedContainer: UnkeyedEncodingContainer {
                                                        nilEncoding: nilEncoding)
     }
 
-    func superEncoder() -> any Encoder {
+    func superEncoder() -> sending any Encoder {
         defer { count += 1 }
 
         return _URLEncodedFormEncoder(context: context,
@@ -1075,7 +1075,7 @@ final class URLEncodedFormSerializer {
         self.allowedCharacters = allowedCharacters
     }
 
-    func serialize(_ object: URLEncodedFormComponent.Object) -> String {
+    func serialize(_ object: URLEncodedFormComponent.Object) -> sending String {
         var output: [String] = []
         for (key, component) in object {
             let value = serialize(component, forKey: key)
@@ -1086,7 +1086,7 @@ final class URLEncodedFormSerializer {
         return output.joinedWithAmpersands()
     }
 
-    func serialize(_ component: URLEncodedFormComponent, forKey key: String) -> String {
+    func serialize(_ component: URLEncodedFormComponent, forKey key: String) -> sending String {
         switch component {
         case let .string(string): "\(escape(keyEncoding.encode(key)))=\(escape(string))"
         case let .array(array): serialize(array, forKey: key)
@@ -1094,7 +1094,7 @@ final class URLEncodedFormSerializer {
         }
     }
 
-    func serialize(_ object: URLEncodedFormComponent.Object, forKey key: String) -> String {
+    func serialize(_ object: URLEncodedFormComponent.Object, forKey key: String) -> sending String {
         var segments: [String] = object.map { subKey, value in
             let keyPath = keyPathEncoding.encodeKeyPath(subKey)
             return serialize(value, forKey: key + keyPath)
@@ -1104,7 +1104,7 @@ final class URLEncodedFormSerializer {
         return segments.joinedWithAmpersands()
     }
 
-    func serialize(_ array: [URLEncodedFormComponent], forKey key: String) -> String {
+    func serialize(_ array: [URLEncodedFormComponent], forKey key: String) -> sending String {
         var segments: [String] = array.enumerated().map { index, component in
             let keyPath = arrayEncoding.encode(key, atIndex: index)
             return serialize(component, forKey: keyPath)
@@ -1114,7 +1114,7 @@ final class URLEncodedFormSerializer {
         return segments.joinedWithAmpersands()
     }
 
-    func escape(_ query: String) -> String {
+    func escape(_ query: String) -> sending String {
         var allowedCharactersWithSpace = allowedCharacters
         allowedCharactersWithSpace.insert(charactersIn: " ")
         let escapedQuery = query.addingPercentEncoding(withAllowedCharacters: allowedCharactersWithSpace) ?? query
@@ -1125,7 +1125,7 @@ final class URLEncodedFormSerializer {
 }
 
 extension [String] {
-    func joinedWithAmpersands() -> String {
+    func joinedWithAmpersands() -> sending String {
         joined(separator: "&")
     }
 }

--- a/Source/Features/Validation.swift
+++ b/Source/Features/Validation.swift
@@ -54,7 +54,7 @@ extension Request {
             }
         }
 
-        func matches(_ mime: MIMEType) -> Bool {
+        func matches(_ mime: MIMEType) -> sending Bool {
             switch (type, subtype) {
             case (mime.type, mime.subtype), (mime.type, "*"), ("*", mime.subtype), ("*", "*"):
                 true
@@ -79,8 +79,7 @@ extension Request {
     // MARK: Status Code
 
     fileprivate func validate<S: Sequence>(statusCode acceptableStatusCodes: S,
-                                           response: HTTPURLResponse)
-        -> ValidationResult
+                                           response: HTTPURLResponse) -> sending ValidationResult
         where S.Iterator.Element == Int {
         if acceptableStatusCodes.contains(response.statusCode) {
             return .success(())
@@ -94,8 +93,7 @@ extension Request {
 
     fileprivate func validate<S: Sequence>(contentType acceptableContentTypes: S,
                                            response: HTTPURLResponse,
-                                           isEmpty: Bool)
-        -> ValidationResult
+                                           isEmpty: Bool) -> sending ValidationResult
         where S.Iterator.Element == String {
         guard !isEmpty else { return .success(()) }
 
@@ -103,8 +101,7 @@ extension Request {
     }
 
     fileprivate func validate<S: Sequence>(contentType acceptableContentTypes: S,
-                                           response: HTTPURLResponse)
-        -> ValidationResult
+                                           response: HTTPURLResponse) -> sending ValidationResult
         where S.Iterator.Element == String {
         guard
             let responseContentType = response.mimeType,
@@ -146,7 +143,7 @@ extension Request {
 extension DataRequest {
     /// A closure used to validate a request that takes a URL request, a URL response and data, and returns whether the
     /// request was valid.
-    public typealias Validation = @Sendable (URLRequest?, HTTPURLResponse, Data?) -> ValidationResult
+    public typealias Validation = (URLRequest?, HTTPURLResponse, Data?) -> sending ValidationResult
 
     /// Validates that the response has a status code in the specified sequence.
     ///
@@ -157,7 +154,7 @@ extension DataRequest {
     /// - Returns:                         The instance.
     @preconcurrency
     @discardableResult
-    public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int, S: Sendable {
+    public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> sending Self where S.Iterator.Element == Int, S: Sendable {
         validate { [unowned self] _, response, _ in
             self.validate(statusCode: acceptableStatusCodes, response: response)
         }
@@ -172,7 +169,7 @@ extension DataRequest {
     /// - returns: The request.
     @preconcurrency
     @discardableResult
-    public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping @Sendable @autoclosure () -> S) -> Self where S.Iterator.Element == String, S: Sendable {
+    public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping  @autoclosure () -> sending S) -> Self where S.Iterator.Element == String, S: Sendable {
         validate { [unowned self] _, response, data in
             self.validate(contentType: acceptableContentTypes(), response: response, isEmpty: (data == nil || data?.isEmpty == true))
         }
@@ -185,8 +182,8 @@ extension DataRequest {
     ///
     /// - returns: The request.
     @discardableResult
-    public func validate() -> Self {
-        let contentTypes: @Sendable () -> [String] = { [unowned self] in
+    public func validate() -> sending Self {
+        let contentTypes: () -> sending [String] = { [unowned self] in
             acceptableContentTypes
         }
         return validate(statusCode: acceptableStatusCodes).validate(contentType: contentTypes())
@@ -196,7 +193,7 @@ extension DataRequest {
 extension DataStreamRequest {
     /// A closure used to validate a request that takes a `URLRequest` and `HTTPURLResponse` and returns whether the
     /// request was valid.
-    public typealias Validation = @Sendable (_ request: URLRequest?, _ response: HTTPURLResponse) -> ValidationResult
+    public typealias Validation = (_ request: URLRequest?, _ response: HTTPURLResponse) -> sending ValidationResult
 
     /// Validates that the response has a status code in the specified sequence.
     ///
@@ -207,7 +204,7 @@ extension DataStreamRequest {
     /// - Returns:                         The instance.
     @preconcurrency
     @discardableResult
-    public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int, S: Sendable {
+    public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> sending Self where S.Iterator.Element == Int, S: Sendable {
         validate { [unowned self] _, response in
             self.validate(statusCode: acceptableStatusCodes, response: response)
         }
@@ -222,7 +219,7 @@ extension DataStreamRequest {
     /// - returns: The request.
     @preconcurrency
     @discardableResult
-    public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping @Sendable @autoclosure () -> S) -> Self where S.Iterator.Element == String, S: Sendable {
+    public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping  @autoclosure () -> sending S) -> Self where S.Iterator.Element == String, S: Sendable {
         validate { [unowned self] _, response in
             self.validate(contentType: acceptableContentTypes(), response: response)
         }
@@ -235,8 +232,8 @@ extension DataStreamRequest {
     ///
     /// - Returns: The instance.
     @discardableResult
-    public func validate() -> Self {
-        let contentTypes: @Sendable () -> [String] = { [unowned self] in
+    public func validate() -> sending Self {
+        let contentTypes: () -> sending [String] = { [unowned self] in
             acceptableContentTypes
         }
         return validate(statusCode: acceptableStatusCodes).validate(contentType: contentTypes())
@@ -248,10 +245,9 @@ extension DataStreamRequest {
 extension DownloadRequest {
     /// A closure used to validate a request that takes a URL request, a URL response, a temporary URL and a
     /// destination URL, and returns whether the request was valid.
-    public typealias Validation = @Sendable (_ request: URLRequest?,
+    public typealias Validation = (_ request: URLRequest?,
                                              _ response: HTTPURLResponse,
-                                             _ fileURL: URL?)
-        -> ValidationResult
+                                             _ fileURL: URL?) -> sending ValidationResult
 
     /// Validates that the response has a status code in the specified sequence.
     ///
@@ -262,7 +258,7 @@ extension DownloadRequest {
     /// - Returns:                         The instance.
     @preconcurrency
     @discardableResult
-    public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> Self where S.Iterator.Element == Int, S: Sendable {
+    public func validate<S: Sequence>(statusCode acceptableStatusCodes: S) -> sending Self where S.Iterator.Element == Int, S: Sendable {
         validate { [unowned self] _, response, _ in
             self.validate(statusCode: acceptableStatusCodes, response: response)
         }
@@ -277,7 +273,7 @@ extension DownloadRequest {
     /// - returns: The request.
     @preconcurrency
     @discardableResult
-    public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping @Sendable @autoclosure () -> S) -> Self where S.Iterator.Element == String, S: Sendable {
+    public func validate<S: Sequence>(contentType acceptableContentTypes: @escaping  @autoclosure () -> sending S) -> Self where S.Iterator.Element == String, S: Sendable {
         validate { [unowned self] _, response, fileURL in
             guard let fileURL else {
                 return .failure(AFError.responseValidationFailed(reason: .dataFileNil))
@@ -299,8 +295,8 @@ extension DownloadRequest {
     ///
     /// - returns: The request.
     @discardableResult
-    public func validate() -> Self {
-        let contentTypes: @Sendable () -> [String] = { [unowned self] in
+    public func validate() -> sending Self {
+        let contentTypes: () -> sending [String] = { [unowned self] in
             acceptableContentTypes
         }
         return validate(statusCode: acceptableStatusCodes).validate(contentType: contentTypes())


### PR DESCRIPTION
## Summary
- update closure types to use `sending` effect instead of `@Sendable`
- adjust overrides for new signatures
- tweak cancelation closure to avoid type ambiguity

## Testing
- `swift build`
- `swift test` *(fails: fatalError during tests)*